### PR TITLE
wildchat_shorten

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ test.py
 models/
 distill/
 data/*_devonly.json
+boxed.py
 
 # Byte-compiled / optimized / DLL files
 __pycache__/


### PR DESCRIPTION
1) some examples in wildchat are too long, shorten them to at most 512 tokens
2) adding gitignore for a file on my local end