### PR TITLE
Reasoning models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ boxed.py
 gpt_rejudge.py
 config.slurm
 log.txt
+moco/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/method/distributed_generation.py
+++ b/method/distributed_generation.py
@@ -70,6 +70,12 @@ def batch_generate_text(model_name, gpu_id, input_list, max_response_length, tem
             )
         decoded_outputs = tokenizer.batch_decode(outputs[:, inputs.input_ids.shape[1]:], skip_special_tokens=True)
         # decoded_outputs = tokenizer.batch_decode(outputs, skip_special_tokens=True)
+
+        # thinking model compatibility
+        for idx in range(len(decoded_outputs)):
+            if "</think>" in decoded_outputs[idx]:
+                decoded_outputs[idx] = decoded_outputs[idx].split("</think>")[-1].strip()
+
         output_list.extend(decoded_outputs)
     del model
     del tokenizer

--- a/method/user_readme.md
+++ b/method/user_readme.md
@@ -27,6 +27,8 @@ len(gpu_ids) can be fewer than len(model_names) in most approaches. But please, 
 
 If you are trying to run collaboration with one of the model being too large to fit onto a single GPU: add `"big_model_mode": true` to `"hyperparameters"`: it will use all provided GPUs for a single model in rotation. This will only work for some approaches.
 
+Reasoning LMs are supported! Please use much larger `"max_response_length"` to account for them: we will parse the text after `</think>` as the actual model output.
+
 #### API-level: Prompt Routing
 - file: `api_prompt_routing.py`
 - description: prompt an LLM to route among the candidate LLMs based on their descriptions. First, evaluate models on the dev set to determine who is best and use it for the routing. Then, given (model descriptions, query), this LLM decides which candidate model (including itself) should be selected. Finally, generation with the selected LLM for each query.


### PR DESCRIPTION
Add support for reasoning models, by that I mean: politely suggesting people to use much larger `max_response_length` if reasoning models are included, and parse the text after `</think>` as actual model output.

Ziyuan, if you can/want, you can do this for batch_generate_text_with_score too: I didn't do this fearing that I don't understand the logit extraction logic fully and might mess things up.