### PR TITLE
dare_ties_fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ boxed.py
 gpt_rejudge.py
 config.slurm
 log.txt
+*.txt
 moco/
 
 # Byte-compiled / optimized / DLL files

--- a/method/user_readme.md
+++ b/method/user_readme.md
@@ -235,11 +235,12 @@ Reasoning LMs are supported! Please use much larger `"max_response_length"` to a
     - [Language Models are Super Mario: Absorbing Abilities from Homologous Models as a Free Lunch](https://arxiv.org/abs/2311.03099)
     - [TIES-Merging: Resolving Interference When Merging Models](https://arxiv.org/abs/2306.01708)
 - method-specific hyperparameters:
+    - `base_model_name`: the common base that these finetuned models share. For example, `Qwen/Qwen2.5-7B-Instruct` for ["bunsenfeng/yuru_qw_wizardlm", "bunsenfeng/yuru_qw_sharegpt", "bunsenfeng/yuru_qw_oasst1"].
     - `mode`, default `average`: `average` or `optimized`.
     - `population`, default 5: the population size for particle swarm optimization (only used in `optimized` mode).
     - `max_iterations`, default 5: the maximum number of iterations for particle swarm optimization (only used in `optimized` mode).
     - There are more hyperparameters in `optimized` mode for particle swarm optimization, please refer to `weight_dare_ties.py`. Only change them if you know what you are doing.
-- note to tester: one recommended `model_names`: ["allenai/Llama-3.1-Tulu-3-8B-SFT", "allenai/Llama-3.1-Tulu-3-8B-DPO", "allenai/Llama-3.1-Tulu-3-8B"]. Try another set of your own choices.
+- note to tester: one recommended `model_names`: base_model_name `Qwen/Qwen2.5-7B-Instruct` for ["bunsenfeng/yuru_qw_wizardlm", "bunsenfeng/yuru_qw_sharegpt", "bunsenfeng/yuru_qw_oasst1"]. Try another set of your own choices.
 
 #### Weight-level: Model Swarms
 - file: `weight_model_swarms.py`

--- a/method/weight_dare_ties.py
+++ b/method/weight_dare_ties.py
@@ -18,6 +18,9 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     model_names = lora_check.lora_to_full(model_names)
 
     # method-specific hyperparameters
+
+    base_model_name = hyperparameters.get("base_model_name")
+
     population = hyperparameters.get("population", 5)
     max_iterations = hyperparameters.get("max_iterations", 5)
     mode = hyperparameters.get("mode", "average") # optimized or average
@@ -83,7 +86,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
                         f.write("    parameters:\n")
                         f.write("      weight: " + str(weight[j]) + "\n")
                     f.write("merge_method: dare_ties\n")
-                    f.write("base_model: " + model_names[0] + "\n")
+                    f.write("base_model: " + base_model_name + "\n")
                     f.write("dtype: float16\n")
                 
                 os.system("mergekit-yaml " + dare_ties_base_path + "dare_ties.yml " + merged_model_path + " --cuda --device cuda:" + str(gpu_id))
@@ -130,7 +133,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
             f.write("    parameters:\n")
             f.write("      weight: " + str(normalized_best_weights[j]) + "\n")
         f.write("merge_method: dare_ties\n")
-        f.write("base_model: " + model_names[0] + "\n")
+        f.write("base_model: " + base_model_name + "\n")
         f.write("dtype: float16\n")
 
     os.system("mergekit-yaml " + dare_ties_base_path + "dare_ties.yml " + merged_model_path)


### PR DESCRIPTION
I find that in dare_ties of mergekit, you have to specify the common base model of the adapters, not one of the adapters, as `base_model`.

Adding a required hyperparameter to ask the user for that.

Ziyuan, can you please test the new setting and observe whether the outputs are looking alright?