### PR TITLE
add one test case in mbpp input

### DIFF
--- a/data/mbpp.json
+++ b/data/mbpp.json
@@ -4,2923 +4,2923 @@
   "dev": [
     {
       "id": 677,
-      "input": "Write a function to check if the triangle is valid or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check if the triangle is valid or not.\nYour code should pass this test case: assert validity_triangle(60,50,90)==False",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(60,50,90)==False\n    assert candidate(45,75,60)==True\n    assert candidate(30,50,100)==True\n",
       "language": "python"
     },
     {
       "id": 580,
-      "input": "Write a function to extract the even elements in the nested mixed tuple.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to extract the even elements in the nested mixed tuple.\nYour code should pass this test case: assert extract_even((4, 5, (7, 6, (2, 4)), 6, 8)) == (4, (6, (2, 4)), 6, 8)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((4, 5, (7, 6, (2, 4)), 6, 8)) == (4, (6, (2, 4)), 6, 8)\n    assert candidate((5, 6, (8, 7, (4, 8)), 7, 9)) == (6, (8, (4, 8)))\n    assert candidate((5, 6, (9, 8, (4, 6)), 8, 10)) == (6, (8, (4, 6)), 8, 10)\n",
       "language": "python"
     },
     {
       "id": 964,
-      "input": "Write a python function to check whether the length of the word is even or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether the length of the word is even or not.\nYour code should pass this test case: assert word_len(\"program\") == False",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"program\") == False\n    assert candidate(\"solution\") == True\n    assert candidate(\"data\") == True\n",
       "language": "python"
     },
     {
       "id": 851,
-      "input": "Write a python function to find sum of inverse of divisors.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find sum of inverse of divisors.\nYour code should pass this test case: assert Sum_of_Inverse_Divisors(6,12) == 2",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(6,12) == 2\n    assert candidate(9,13) == 1.44\n    assert candidate(1,4) == 4\n",
       "language": "python"
     },
     {
       "id": 725,
-      "input": "Write a function to extract values between quotation marks of the given string by using regex.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to extract values between quotation marks of the given string by using regex.\nYour code should pass this test case: assert extract_quotation('Cortex \"A53\" Based \"multi\" tasking \"Processor\"') == ['A53', 'multi', 'Processor']",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('Cortex \"A53\" Based \"multi\" tasking \"Processor\"') == ['A53', 'multi', 'Processor']\n    assert candidate('Cast your \"favorite\" entertainment \"apps\"') == ['favorite', 'apps']\n    assert candidate('Watch content \"4k Ultra HD\" resolution with \"HDR 10\" Support') == ['4k Ultra HD', 'HDR 10']\n",
       "language": "python"
     },
     {
       "id": 138,
-      "input": "Write a python function to check whether the given number can be represented as sum of non-zero powers of 2 or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether the given number can be represented as sum of non-zero powers of 2 or not.\nYour code should pass this test case: assert is_Sum_Of_Powers_Of_Two(10) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10) == True\n    assert candidate(7) == False\n    assert candidate(14) == True\n",
       "language": "python"
     },
     {
       "id": 586,
-      "input": "Write a python function to split the array and add the first part to the end.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to split the array and add the first part to the end.\nYour code should pass this test case: assert split_Arr([12,10,5,6,52,36],6,2) == [5,6,52,36,12,10]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([12,10,5,6,52,36],6,2) == [5,6,52,36,12,10]\n    assert candidate([1,2,3,4],4,1) == [2,3,4,1]\n    assert candidate([0,1,2,3,4,5,6,7],8,3) == [3,4,5,6,7,0,1,2]\n",
       "language": "python"
     },
     {
       "id": 854,
-      "input": "Write a function which accepts an arbitrary list and converts it to a heap using heap queue algorithm.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function which accepts an arbitrary list and converts it to a heap using heap queue algorithm.\nYour code should pass this test case: assert raw_heap([25, 44, 68, 21, 39, 23, 89])==[21, 25, 23, 44, 39, 68, 89]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([25, 44, 68, 21, 39, 23, 89])==[21, 25, 23, 44, 39, 68, 89]\n    assert candidate([25, 35, 22, 85, 14, 65, 75, 25, 58])== [14, 25, 22, 25, 35, 65, 75, 85, 58]\n    assert candidate([4, 5, 6, 2])==[2, 4, 6, 5]\n",
       "language": "python"
     },
     {
       "id": 269,
-      "input": "Write a function to find the ascii value of a character.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the ascii value of a character.\nYour code should pass this test case: assert ascii_value('A')==65",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('A')==65\n    assert candidate('R')==82\n    assert candidate('S')==83\n",
       "language": "python"
     },
     {
       "id": 349,
-      "input": "Write a python function to check whether the given string is a binary string or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether the given string is a binary string or not.\nYour code should pass this test case: assert check(\"01010101010\") == \"Yes\"",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"01010101010\") == \"Yes\"\n    assert candidate(\"name0\") == \"No\"\n    assert candidate(\"101\") == \"Yes\"\n",
       "language": "python"
     },
     {
       "id": 600,
-      "input": "Write a python function to check whether the given number is even or not using bitwise operator.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether the given number is even or not using bitwise operator.\nYour code should pass this test case: assert is_Even(1) == False",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(1) == False\n    assert candidate(2) == True\n    assert candidate(3) == False\n",
       "language": "python"
     },
     {
       "id": 546,
-      "input": "Write a function to find the last occurrence of a character in a string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the last occurrence of a character in a string.\nYour code should pass this test case: assert last_occurence_char(\"hello world\",'l')==10",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"hello world\",'l')==10\n    assert candidate(\"language\",'g')==7\n    assert candidate(\"little\",'y')==None\n",
       "language": "python"
     },
     {
       "id": 743,
-      "input": "Write a function to rotate a given list by specified number of items to the right direction.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to rotate a given list by specified number of items to the right direction.\nYour code should pass this test case: assert rotate_right([1, 2, 3, 4, 5, 6, 7, 8, 9, 10],3,4)==[8, 9, 10, 1, 2, 3, 4, 5, 6]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10],3,4)==[8, 9, 10, 1, 2, 3, 4, 5, 6]\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10],2,2)==[9, 10, 1, 2, 3, 4, 5, 6, 7, 8]\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10],5,2)==[6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8]\n",
       "language": "python"
     },
     {
       "id": 70,
-      "input": "Write a function to find whether all the given tuples have equal length or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find whether all the given tuples have equal length or not.\nYour code should pass this test case: assert get_equal([(11, 22, 33), (44, 55, 66)], 3) == 'All tuples have same length'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([(11, 22, 33), (44, 55, 66)], 3) == 'All tuples have same length'\n    assert candidate([(1, 2, 3), (4, 5, 6, 7)], 3) == 'All tuples do not have same length'\n    assert candidate([(1, 2), (3, 4)], 2) == 'All tuples have same length'\n",
       "language": "python"
     },
     {
       "id": 210,
-      "input": "Write a function to check that the given string contains only a certain set of characters(in this case a-z, a-z and 0-9) by using regex.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check that the given string contains only a certain set of characters(in this case a-z, a-z and 0-9) by using regex.\nYour code should pass this test case: assert is_allowed_specific_char(\"ABCDEFabcdef123450\") == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"ABCDEFabcdef123450\") == True\n    assert candidate(\"*&%@#!}{\") == False\n    assert candidate(\"HELLOhowareyou98765\") == True\n",
       "language": "python"
     },
     {
       "id": 654,
-      "input": "Write a function to find the perimeter of a rectangle.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the perimeter of a rectangle.\nYour code should pass this test case: assert rectangle_perimeter(10,20)==60",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10,20)==60\n    assert candidate(10,5)==30\n    assert candidate(4,2)==12\n",
       "language": "python"
     },
     {
       "id": 969,
-      "input": "Write a function to join the tuples if they have similar initial elements.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to join the tuples if they have similar initial elements.\nYour code should pass this test case: assert join_tuples([(5, 6), (5, 7), (6, 8), (6, 10), (7, 13)] ) == [(5, 6, 7), (6, 8, 10), (7, 13)]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([(5, 6), (5, 7), (6, 8), (6, 10), (7, 13)] ) == [(5, 6, 7), (6, 8, 10), (7, 13)]\n    assert candidate([(6, 7), (6, 8), (7, 9), (7, 11), (8, 14)] ) == [(6, 7, 8), (7, 9, 11), (8, 14)]\n    assert candidate([(7, 8), (7, 9), (8, 10), (8, 12), (9, 15)] ) == [(7, 8, 9), (8, 10, 12), (9, 15)]\n",
       "language": "python"
     },
     {
       "id": 850,
-      "input": "Write a function to check if a triangle of positive area is possible with the given angles.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check if a triangle of positive area is possible with the given angles.\nYour code should pass this test case: assert is_triangleexists(50,60,70)==True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(50,60,70)==True\n    assert candidate(90,45,45)==True\n    assert candidate(150,30,70)==False\n",
       "language": "python"
     },
     {
       "id": 858,
-      "input": "Write a function to count number of lists in a given list of lists and square the count.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to count number of lists in a given list of lists and square the count.\nYour code should pass this test case: assert count_list([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]])==25",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]])==25\n    assert candidate([[1, 3], [5, 7], [9, 11], [13, 15, 17]] )==16\n    assert candidate([[2, 4], [[6,8], [4,5,8]], [10, 12, 14]])==9\n",
       "language": "python"
     },
     {
       "id": 3,
-      "input": "Write a python function to identify non-prime numbers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to identify non-prime numbers.\nYour code should pass this test case: assert is_not_prime(2) == False",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(2) == False\n    assert candidate(10) == True\n    assert candidate(35) == True\n",
       "language": "python"
     },
     {
       "id": 352,
-      "input": "Write a python function to check whether all the characters in a given string are unique.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether all the characters in a given string are unique.\nYour code should pass this test case: assert unique_Characters('aba') == False",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('aba') == False\n    assert candidate('abc') == True\n    assert candidate('abab') == False\n",
       "language": "python"
     },
     {
       "id": 724,
-      "input": "Write a function to calculate the sum of all digits of the base to the specified power.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to calculate the sum of all digits of the base to the specified power.\nYour code should pass this test case: assert power_base_sum(2,100)==115",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(2,100)==115\n    assert candidate(8,10)==37\n    assert candidate(8,15)==62\n",
       "language": "python"
     },
     {
       "id": 527,
-      "input": "Write a function to find all pairs in an integer array whose sum is equal to a given number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find all pairs in an integer array whose sum is equal to a given number.\nYour code should pass this test case: assert get_pairs_count([1, 5, 7, -1, 5], 5, 6) == 3",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 5, 7, -1, 5], 5, 6) == 3\n    assert candidate([1, 5, 7, -1], 4, 6) == 2\n    assert candidate([1, 1, 1, 1], 4, 2) == 6\n",
       "language": "python"
     },
     {
       "id": 179,
-      "input": "Write a function to find if the given number is a keith number or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find if the given number is a keith number or not.\nYour code should pass this test case: assert is_num_keith(14) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(14) == True\n    assert candidate(12) == False\n    assert candidate(197) == True\n",
       "language": "python"
     },
     {
       "id": 285,
-      "input": "Write a function that matches a string that has an a followed by two to three 'b'.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function that matches a string that has an a followed by two to three 'b'.\nYour code should pass this test case: assert text_match_two_three(\"ac\")==('Not matched!')",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"ac\")==('Not matched!')\n    assert candidate(\"dc\")==('Not matched!')\n    assert candidate(\"abbbba\")==('Found a match!')\n",
       "language": "python"
     },
     {
       "id": 813,
-      "input": "Write a function to find length of the string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find length of the string.\nYour code should pass this test case: assert string_length('python')==6",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('python')==6\n    assert candidate('program')==7\n    assert candidate('language')==8\n",
       "language": "python"
     },
     {
       "id": 102,
-      "input": "Write a function to convert snake case string to camel case string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to convert snake case string to camel case string.\nYour code should pass this test case: assert snake_to_camel('python_program')=='PythonProgram'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('python_program')=='PythonProgram'\n    assert candidate('python_language')==('PythonLanguage')\n    assert candidate('programming_language')==('ProgrammingLanguage')\n",
       "language": "python"
     },
     {
       "id": 764,
-      "input": "Write a python function to count numeric values in a given string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count numeric values in a given string.\nYour code should pass this test case: assert number_ctr('program2bedone') == 1",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('program2bedone') == 1\n    assert candidate('3wonders') ==1\n    assert candidate('123') == 3\n",
       "language": "python"
     },
     {
       "id": 855,
-      "input": "Write a python function to check for even parity of a given number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check for even parity of a given number.\nYour code should pass this test case: assert check_Even_Parity(10) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10) == True\n    assert candidate(11) == False\n    assert candidate(18) == True\n",
       "language": "python"
     },
     {
       "id": 585,
-      "input": "Write a function to find the n - expensive price items from a given dataset using heap queue algorithm.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the n - expensive price items from a given dataset using heap queue algorithm.\nYour code should pass this test case: assert expensive_items([{'name': 'Item-1', 'price': 101.1},{'name': 'Item-2', 'price': 555.22}],1)==[{'name': 'Item-2', 'price': 555.22}]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([{'name': 'Item-1', 'price': 101.1},{'name': 'Item-2', 'price': 555.22}],1)==[{'name': 'Item-2', 'price': 555.22}]\n    assert candidate([{'name': 'Item-1', 'price': 101.1},{'name': 'Item-2', 'price': 555.22}, {'name': 'Item-3', 'price': 45.09}],2)==[{'name': 'Item-2', 'price': 555.22},{'name': 'Item-1', 'price': 101.1}]\n    assert candidate([{'name': 'Item-1', 'price': 101.1},{'name': 'Item-2', 'price': 555.22}, {'name': 'Item-3', 'price': 45.09},{'name': 'Item-4', 'price': 22.75}],1)==[{'name': 'Item-2', 'price': 555.22}]\n",
       "language": "python"
     },
     {
       "id": 564,
-      "input": "Write a python function to count unequal element pairs from the given array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count unequal element pairs from the given array.\nYour code should pass this test case: assert count_Pairs([1,2,1],3) == 2",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,1],3) == 2\n    assert candidate([1,1,1,1],4) == 0\n    assert candidate([1,2,3,4,5],5) == 10\n",
       "language": "python"
     },
     {
       "id": 739,
-      "input": "Write a python function to find the index of smallest triangular number with n digits.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the index of smallest triangular number with n digits.\nYour code should pass this test case: assert find_Index(2) == 4",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(2) == 4\n    assert candidate(3) == 14\n    assert candidate(4) == 45\n",
       "language": "python"
     },
     {
       "id": 742,
-      "input": "Write a function to caluclate the area of a tetrahedron.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to caluclate the area of a tetrahedron.\nYour code should pass this test case: assert area_tetrahedron(3)==15.588457268119894",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(3)==15.588457268119894\n    assert candidate(20)==692.8203230275509\n    assert candidate(10)==173.20508075688772\n",
       "language": "python"
     },
     {
       "id": 752,
-      "input": "Write a function to find the nth jacobsthal number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the nth jacobsthal number.\nYour code should pass this test case: assert jacobsthal_num(5) == 11",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(5) == 11\n    assert candidate(2) == 1\n    assert candidate(4) == 5\n",
       "language": "python"
     },
     {
       "id": 405,
-      "input": "Write a function to check whether an element exists within a tuple.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check whether an element exists within a tuple.\nYour code should pass this test case: assert check_tuplex((\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"),'r')==True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"),'r')==True\n    assert candidate((\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"),'5')==False\n    assert candidate((\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\",\"e\"),3)==True\n",
       "language": "python"
     },
     {
       "id": 407,
-      "input": "Write a function to create the next bigger number by rearranging the digits of a given number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to create the next bigger number by rearranging the digits of a given number.\nYour code should pass this test case: assert rearrange_bigger(12)==21",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(12)==21\n    assert candidate(10)==False\n    assert candidate(102)==120\n",
       "language": "python"
     },
     {
       "id": 437,
-      "input": "Write a function to remove odd characters in a string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to remove odd characters in a string.\nYour code should pass this test case: assert remove_odd(\"python\")==(\"yhn\")",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"python\")==(\"yhn\")\n    assert candidate(\"program\")==(\"rga\")\n    assert candidate(\"language\")==(\"agae\")\n",
       "language": "python"
     },
     {
       "id": 260,
-      "input": "Write a function to find the nth newman\u2013shanks\u2013williams prime number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the nth newman\u2013shanks\u2013williams prime number.\nYour code should pass this test case: assert newman_prime(3) == 7 ",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(3) == 7 \n    assert candidate(4) == 17\n    assert candidate(5) == 41\n",
       "language": "python"
     },
     {
       "id": 922,
-      "input": "Write a function to find a pair with the highest product from a given array of integers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find a pair with the highest product from a given array of integers.\nYour code should pass this test case: assert max_product([1, 2, 3, 4, 7, 0, 8, 4])==(7, 8)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 2, 3, 4, 7, 0, 8, 4])==(7, 8)\n    assert candidate([0, -1, -2, -4, 5, 0, -6])==(-4, -6)\n    assert candidate([1, 3, 5, 6, 8, 9])==(8,9)\n",
       "language": "python"
     },
     {
       "id": 159,
-      "input": "Write a function to print the season for the given month and day.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to print the season for the given month and day.\nYour code should pass this test case: assert month_season('January',4)==('winter')",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('January',4)==('winter')\n    assert candidate('October',28)==('autumn')\n    assert candidate('June',6)==('spring')\n",
       "language": "python"
     },
     {
       "id": 368,
-      "input": "Write a function to repeat the given tuple n times.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to repeat the given tuple n times.\nYour code should pass this test case: assert repeat_tuples((1, 3), 4) == ((1, 3), (1, 3), (1, 3), (1, 3))",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((1, 3), 4) == ((1, 3), (1, 3), (1, 3), (1, 3))\n    assert candidate((1, 2), 3) == ((1, 2), (1, 2), (1, 2))\n    assert candidate((3, 4), 5) == ((3, 4), (3, 4), (3, 4), (3, 4), (3, 4))\n",
       "language": "python"
     },
     {
       "id": 874,
-      "input": "Write a python function to check if the string is a concatenation of another string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check if the string is a concatenation of another string.\nYour code should pass this test case: assert check_Concat(\"abcabcabc\",\"abc\") == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"abcabcabc\",\"abc\") == True\n    assert candidate(\"abcab\",\"abc\") == False\n    assert candidate(\"aba\",\"ab\") == False\n",
       "language": "python"
     },
     {
       "id": 538,
-      "input": "Write a python function to convert a given string list to a tuple.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to convert a given string list to a tuple.\nYour code should pass this test case: assert string_list_to_tuple((\"python 3.0\")) == ('p', 'y', 't', 'h', 'o', 'n', '3', '.', '0')",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((\"python 3.0\")) == ('p', 'y', 't', 'h', 'o', 'n', '3', '.', '0')\n    assert candidate((\"bigdata\")) == ('b', 'i', 'g', 'd', 'a', 't', 'a')\n    assert candidate((\"language\")) == ('l', 'a', 'n', 'g', 'u', 'a', 'g','e')\n",
       "language": "python"
     },
     {
       "id": 80,
-      "input": "Write a function to find the nth tetrahedral number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the nth tetrahedral number.\nYour code should pass this test case: assert tetrahedral_number(5) == 35.0",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(5) == 35.0\n    assert candidate(6) == 56.0\n    assert candidate(7) == 84.0\n",
       "language": "python"
     },
     {
       "id": 678,
-      "input": "Write a python function to remove spaces from a given string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to remove spaces from a given string.\nYour code should pass this test case: assert remove_spaces(\"a b c\") == \"abc\"",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"a b c\") == \"abc\"\n    assert candidate(\"1 2 3\") == \"123\"\n    assert candidate(\" b c\") == \"bc\"\n",
       "language": "python"
     },
     {
       "id": 602,
-      "input": "Write a python function to find the first repeated character in a given string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the first repeated character in a given string.\nYour code should pass this test case: assert first_repeated_char(\"abcabc\") == \"a\"",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"abcabc\") == \"a\"\n    assert candidate(\"abc\") == \"None\"\n    assert candidate(\"123123\") == \"1\"\n",
       "language": "python"
     },
     {
       "id": 876,
-      "input": "Write a python function to find lcm of two positive integers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find lcm of two positive integers.\nYour code should pass this test case: assert lcm(4,6) == 12",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(4,6) == 12\n    assert candidate(15,17) == 255\n    assert candidate(2,6) == 6\n",
       "language": "python"
     },
     {
       "id": 322,
-      "input": "Write a function to find all index positions of the minimum values in a given list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find all index positions of the minimum values in a given list.\nYour code should pass this test case: assert position_min([12,33,23,10,67,89,45,667,23,12,11,10,54])==[3,11]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([12,33,23,10,67,89,45,667,23,12,11,10,54])==[3,11]\n    assert candidate([1,2,2,2,4,4,4,5,5,5,5])==[0]\n    assert candidate([2,1,5,6,8,3,4,9,10,11,8,12])==[1]\n",
       "language": "python"
     },
     {
       "id": 791,
-      "input": "Write a function to remove the nested record from the given tuple.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to remove the nested record from the given tuple.\nYour code should pass this test case: assert remove_nested((1, 5, 7, (4, 6), 10)) == (1, 5, 7, 10)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((1, 5, 7, (4, 6), 10)) == (1, 5, 7, 10)\n    assert candidate((2, 6, 8, (5, 7), 11)) == (2, 6, 8, 11)\n    assert candidate((3, 7, 9, (6, 8), 12)) == (3, 7, 9, 12)\n",
       "language": "python"
     },
     {
       "id": 37,
-      "input": "Write a function to sort a given mixed list of integers and strings.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to sort a given mixed list of integers and strings.\nYour code should pass this test case: assert sort_mixed_list([19,'red',12,'green','blue', 10,'white','green',1])==[1, 10, 12, 19, 'blue', 'green', 'green', 'red', 'white']",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([19,'red',12,'green','blue', 10,'white','green',1])==[1, 10, 12, 19, 'blue', 'green', 'green', 'red', 'white']\n    assert candidate([19,'red',12,'green','blue', 10,'white','green',1])==[1, 10, 12, 19, 'blue', 'green', 'green', 'red', 'white']\n    assert candidate([19,'red',12,'green','blue', 10,'white','green',1])==[1, 10, 12, 19, 'blue', 'green', 'green', 'red', 'white']\n",
       "language": "python"
     },
     {
       "id": 270,
-      "input": "Write a python function to find the sum of even numbers at even positions.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the sum of even numbers at even positions.\nYour code should pass this test case: assert sum_even_and_even_index([5, 6, 12, 1, 18, 8],6) == 30",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([5, 6, 12, 1, 18, 8],6) == 30\n    assert candidate([3, 20, 17, 9, 2, 10, 18, 13, 6, 18],10) == 26\n    assert candidate([5, 6, 12, 1],4) == 12\n",
       "language": "python"
     },
     {
       "id": 335,
-      "input": "Write a function to find the sum of arithmetic progression.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the sum of arithmetic progression.\nYour code should pass this test case: assert ap_sum(1,5,2)==25",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(1,5,2)==25\n    assert candidate(2,6,4)==72\n    assert candidate(1,4,5)==34\n",
       "language": "python"
     },
     {
       "id": 502,
-      "input": "Write a python function to find remainder of two numbers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find remainder of two numbers.\nYour code should pass this test case: assert find(3,3) == 0",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(3,3) == 0\n    assert candidate(10,3) == 1\n    assert candidate(16,5) == 1\n",
       "language": "python"
     },
     {
       "id": 266,
-      "input": "Write a function to find the lateral surface area of a cube.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the lateral surface area of a cube.\nYour code should pass this test case: assert lateralsurface_cube(5)==100",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(5)==100\n    assert candidate(9)==324\n    assert candidate(10)==400\n",
       "language": "python"
     },
     {
       "id": 203,
-      "input": "Write a python function to find the hamming distance between given two integers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the hamming distance between given two integers.\nYour code should pass this test case: assert hamming_Distance(4,8) == 2",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(4,8) == 2\n    assert candidate(2,4) == 2\n    assert candidate(1,2) == 2\n",
       "language": "python"
     },
     {
       "id": 192,
-      "input": "Write a python function to check whether a string has atleast one letter and one number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether a string has atleast one letter and one number.\nYour code should pass this test case: assert check_String('thishasboth29') == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('thishasboth29') == True\n    assert candidate('python') == False\n    assert candidate('string') == False\n",
       "language": "python"
     },
     {
       "id": 201,
-      "input": "Write a python function to check whether the elements in a list are same or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether the elements in a list are same or not.\nYour code should pass this test case: assert chkList(['one','one','one']) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(['one','one','one']) == True\n    assert candidate(['one','Two','Three']) == False\n    assert candidate(['bigdata','python','Django']) == False\n",
       "language": "python"
     },
     {
       "id": 359,
-      "input": "Write a python function to check whether one root of the quadratic equation is twice of the other or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether one root of the quadratic equation is twice of the other or not.\nYour code should pass this test case: assert Check_Solution(1,3,2) == \"Yes\"",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(1,3,2) == \"Yes\"\n    assert candidate(1,2,3) == \"No\"\n    assert candidate(1,-5,6) == \"No\"\n",
       "language": "python"
     },
     {
       "id": 65,
-      "input": "Write a function of recursion list sum.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function of recursion list sum.\nYour code should pass this test case: assert recursive_list_sum(([1, 2, [3,4],[5,6]]))==21",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(([1, 2, [3,4],[5,6]]))==21\n    assert candidate(([7, 10, [15,14],[19,41]]))==106\n    assert candidate(([10, 20, [30,40],[50,60]]))==210\n",
       "language": "python"
     },
     {
       "id": 27,
-      "input": "Write a python function to remove all digits from a list of strings.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to remove all digits from a list of strings.\nYour code should pass this test case: assert remove(['4words', '3letters', '4digits']) == ['words', 'letters', 'digits']",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(['4words', '3letters', '4digits']) == ['words', 'letters', 'digits']\n    assert candidate(['28Jan','12Jan','11Jan']) == ['Jan','Jan','Jan']\n    assert candidate(['wonder1','wonder2','wonder3']) == ['wonder','wonder','wonder']\n",
       "language": "python"
     },
     {
       "id": 483,
-      "input": "Write a python function to find the first natural number whose factorial is divisible by x.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the first natural number whose factorial is divisible by x.\nYour code should pass this test case: assert first_Factorial_Divisible_Number(10) == 5",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10) == 5\n    assert candidate(15) == 5\n    assert candidate(5) == 4\n",
       "language": "python"
     },
     {
       "id": 771,
-      "input": "Write a function to check if the given expression is balanced or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check if the given expression is balanced or not.\nYour code should pass this test case: assert check_expression(\"{()}[{}]\") == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"{()}[{}]\") == True\n    assert candidate(\"{()}[{]\") == False\n    assert candidate(\"{()}[{}][]({})\") == True\n",
       "language": "python"
     },
     {
       "id": 660,
-      "input": "Write a python function to choose points from two ranges such that no point lies in both the ranges.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to choose points from two ranges such that no point lies in both the ranges.\nYour code should pass this test case: assert find_Points(5,10,1,5) == (1,10)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(5,10,1,5) == (1,10)\n    assert candidate(3,5,7,9) == (3,9)\n    assert candidate(1,5,2,8) == (1,8)\n",
       "language": "python"
     },
     {
       "id": 440,
-      "input": "Write a function to find all adverbs and their positions in a given sentence.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find all adverbs and their positions in a given sentence.\nYour code should pass this test case: assert find_adverb_position(\"clearly!! we can see the sky\")==(0, 7, 'clearly')",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"clearly!! we can see the sky\")==(0, 7, 'clearly')\n    assert candidate(\"seriously!! there are many roses\")==(0, 9, 'seriously')\n    assert candidate(\"unfortunately!! sita is going to home\")==(0, 13, 'unfortunately')\n",
       "language": "python"
     },
     {
       "id": 433,
-      "input": "Write a function to check whether the entered number is greater than the elements of the given array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check whether the entered number is greater than the elements of the given array.\nYour code should pass this test case: assert check_greater([1, 2, 3, 4, 5], 4) == 'No, entered number is less than those in the array'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 2, 3, 4, 5], 4) == 'No, entered number is less than those in the array'\n    assert candidate([2, 3, 4, 5, 6], 8) == 'Yes, the entered number is greater than those in the array'\n    assert candidate([9, 7, 4, 8, 6, 1], 11) == 'Yes, the entered number is greater than those in the array'\n",
       "language": "python"
     },
     {
       "id": 971,
-      "input": "Write a function to find the maximum number of segments of lengths a, b and c that can be formed from n.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the maximum number of segments of lengths a, b and c that can be formed from n.\nYour code should pass this test case: assert maximum_segments(7, 5, 2, 5) == 2",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(7, 5, 2, 5) == 2\n    assert candidate(17, 2, 1, 3) == 17\n    assert candidate(18, 16, 3, 6) == 6\n",
       "language": "python"
     },
     {
       "id": 633,
-      "input": "Write a python function to find the sum of xor of all pairs of numbers in the given array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the sum of xor of all pairs of numbers in the given array.\nYour code should pass this test case: assert pair_OR_Sum([5,9,7,6],4) == 47",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([5,9,7,6],4) == 47\n    assert candidate([7,3,5],3) == 12\n    assert candidate([7,3],2) == 4\n",
       "language": "python"
     },
     {
       "id": 567,
-      "input": "Write a function to check whether a specified list is sorted or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check whether a specified list is sorted or not.\nYour code should pass this test case: assert issort_list([1,2,4,6,8,10,12,14,16,17])==True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,4,6,8,10,12,14,16,17])==True\n    assert candidate([1, 2, 4, 6, 8, 10, 12, 14, 20, 17])==False\n    assert candidate([1, 2, 4, 6, 8, 10,15,14,20])==False\n",
       "language": "python"
     },
     {
       "id": 916,
-      "input": "Write a function to find if there is a triplet in the array whose sum is equal to a given value.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find if there is a triplet in the array whose sum is equal to a given value.\nYour code should pass this test case: assert find_triplet_array([1, 4, 45, 6, 10, 8], 6, 22) == (4, 10, 8)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 4, 45, 6, 10, 8], 6, 22) == (4, 10, 8)\n    assert candidate([12, 3, 5, 2, 6, 9], 6, 24) == (12, 3, 9)\n    assert candidate([1, 2, 3, 4, 5], 5, 9) == (1, 3, 5)\n",
       "language": "python"
     },
     {
       "id": 499,
-      "input": "Write a function to find the diameter of a circle.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the diameter of a circle.\nYour code should pass this test case: assert diameter_circle(10)==20",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10)==20\n    assert candidate(40)==80\n    assert candidate(15)==30\n",
       "language": "python"
     },
     {
       "id": 601,
-      "input": "Write a function to find the longest chain which can be formed from the given set of pairs.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the longest chain which can be formed from the given set of pairs.\nYour code should pass this test case: assert max_chain_length([Pair(5, 24), Pair(15, 25),Pair(27, 40), Pair(50, 60)], 4) == 3",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([Pair(5, 24), Pair(15, 25),Pair(27, 40), Pair(50, 60)], 4) == 3\n    assert candidate([Pair(1, 2), Pair(3, 4),Pair(5, 6), Pair(7, 8)], 4) == 4\n    assert candidate([Pair(19, 10), Pair(11, 12),Pair(13, 14), Pair(15, 16), Pair(31, 54)], 5) == 5\n",
       "language": "python"
     },
     {
       "id": 428,
-      "input": "Write a function to sort the given array by using shell sort.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to sort the given array by using shell sort.\nYour code should pass this test case: assert shell_sort([12, 23, 4, 5, 3, 2, 12, 81, 56, 95]) == [2, 3, 4, 5, 12, 12, 23, 56, 81, 95]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([12, 23, 4, 5, 3, 2, 12, 81, 56, 95]) == [2, 3, 4, 5, 12, 12, 23, 56, 81, 95]\n    assert candidate([24, 22, 39, 34, 87, 73, 68]) == [22, 24, 34, 39, 68, 73, 87]\n    assert candidate([32, 30, 16, 96, 82, 83, 74]) == [16, 30, 32, 74, 82, 83, 96]\n",
       "language": "python"
     },
     {
       "id": 552,
-      "input": "Write a python function to check whether a given sequence is linear or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether a given sequence is linear or not.\nYour code should pass this test case: assert Seq_Linear([0,2,4,6,8,10]) == \"Linear Sequence\"",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([0,2,4,6,8,10]) == \"Linear Sequence\"\n    assert candidate([1,2,3]) == \"Linear Sequence\"\n    assert candidate([1,5,2]) == \"Non Linear Sequence\"\n",
       "language": "python"
     },
     {
       "id": 640,
-      "input": "Write a function to remove the parenthesis area in a string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to remove the parenthesis area in a string.\nYour code should pass this test case: assert remove_parenthesis([\"python (chrome)\"])==(\"python\")",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([\"python (chrome)\"])==(\"python\")\n    assert candidate([\"string(.abc)\"])==(\"string\")\n    assert candidate([\"alpha(num)\"])==(\"alpha\")\n",
       "language": "python"
     },
     {
       "id": 272,
-      "input": "Write a function to perfom the rear element extraction from list of tuples records.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to perfom the rear element extraction from list of tuples records.\nYour code should pass this test case: assert rear_extract([(1, 'Rash', 21), (2, 'Varsha', 20), (3, 'Kil', 19)]) == [21, 20, 19]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([(1, 'Rash', 21), (2, 'Varsha', 20), (3, 'Kil', 19)]) == [21, 20, 19]\n    assert candidate([(1, 'Sai', 36), (2, 'Ayesha', 25), (3, 'Salman', 45)]) == [36, 25, 45]\n    assert candidate([(1, 'Sudeep', 14), (2, 'Vandana', 36), (3, 'Dawood', 56)]) == [14, 36, 56]\n",
       "language": "python"
     },
     {
       "id": 358,
-      "input": "Write a function to find modulo division of two lists using map and lambda function.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find modulo division of two lists using map and lambda function.\nYour code should pass this test case: assert moddiv_list([4,5,6],[1, 2, 3])==[0, 1, 0]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([4,5,6],[1, 2, 3])==[0, 1, 0]\n    assert candidate([3,2],[1,4])==[0, 2]\n    assert candidate([90,120],[50,70])==[40, 50]\n",
       "language": "python"
     },
     {
       "id": 103,
-      "input": "Write a function to find eulerian number a(n, m).",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find eulerian number a(n, m).\nYour code should pass this test case: assert eulerian_num(3, 1) == 4",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(3, 1) == 4\n    assert candidate(4, 1) == 11\n    assert candidate(5, 3) == 26\n",
       "language": "python"
     },
     {
       "id": 888,
-      "input": "Write a function to substract the elements of the given nested tuples.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to substract the elements of the given nested tuples.\nYour code should pass this test case: assert substract_elements(((1, 3), (4, 5), (2, 9), (1, 10)), ((6, 7), (3, 9), (1, 1), (7, 3))) == ((-5, -4), (1, -4), (1, 8), (-6, 7))",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(((1, 3), (4, 5), (2, 9), (1, 10)), ((6, 7), (3, 9), (1, 1), (7, 3))) == ((-5, -4), (1, -4), (1, 8), (-6, 7))\n    assert candidate(((13, 4), (14, 6), (13, 10), (12, 11)), ((19, 8), (14, 10), (12, 2), (18, 4))) == ((-6, -4), (0, -4), (1, 8), (-6, 7))\n    assert candidate(((19, 5), (18, 7), (19, 11), (17, 12)), ((12, 9), (17, 11), (13, 3), (19, 5))) == ((7, -4), (1, -4), (6, 8), (-2, 7))\n",
       "language": "python"
     },
     {
       "id": 881,
-      "input": "Write a function to find the sum of first even and odd number of a given list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the sum of first even and odd number of a given list.\nYour code should pass this test case: assert sum_even_odd([1,3,5,7,4,1,6,8])==5",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,3,5,7,4,1,6,8])==5\n    assert candidate([1,2,3,4,5,6,7,8,9,10])==3\n    assert candidate([1,5,7,9,10])==11\n",
       "language": "python"
     },
     {
       "id": 965,
-      "input": "Write a function to convert camel case string to snake case string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to convert camel case string to snake case string.\nYour code should pass this test case: assert camel_to_snake('PythonProgram')==('python_program')",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('PythonProgram')==('python_program')\n    assert candidate('pythonLanguage')==('python_language')\n    assert candidate('ProgrammingLanguage')==('programming_language')\n",
       "language": "python"
     },
     {
       "id": 119,
-      "input": "Write a python function to find the element that appears only once in a sorted array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the element that appears only once in a sorted array.\nYour code should pass this test case: assert search([1,1,2,2,3],5) == 3",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,1,2,2,3],5) == 3\n    assert candidate([1,1,3,3,4,4,5,5,7,7,8],11) == 8\n    assert candidate([1,2,2,3,3,4,4],7) == 1\n",
       "language": "python"
     },
     {
       "id": 253,
-      "input": "Write a python function to count integers from a given list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count integers from a given list.\nYour code should pass this test case: assert count_integer([1,2,'abc',1.2]) == 2",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,'abc',1.2]) == 2\n    assert candidate([1,2,3]) == 3\n    assert candidate([1,1.2,4,5.1]) == 2\n",
       "language": "python"
     },
     {
       "id": 105,
-      "input": "Write a python function to count true booleans in the given list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count true booleans in the given list.\nYour code should pass this test case: assert count([True,False,True]) == 2",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([True,False,True]) == 2\n    assert candidate([False,False]) == 0\n    assert candidate([True,True,True]) == 3\n",
       "language": "python"
     },
     {
       "id": 776,
-      "input": "Write a function to count those characters which have vowels as their neighbors in the given string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to count those characters which have vowels as their neighbors in the given string.\nYour code should pass this test case: assert count_vowels('bestinstareels') == 7",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('bestinstareels') == 7\n    assert candidate('partofthejourneyistheend') == 12\n    assert candidate('amazonprime') == 5\n",
       "language": "python"
     },
     {
       "id": 699,
-      "input": "Write a python function to find the minimum number of swaps required to convert one binary string to another.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the minimum number of swaps required to convert one binary string to another.\nYour code should pass this test case: assert min_Swaps(\"1101\",\"1110\") == 1",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"1101\",\"1110\") == 1\n    assert candidate(\"1111\",\"0100\") == \"Not Possible\"\n    assert candidate(\"1110000\",\"0001101\") == 3\n",
       "language": "python"
     },
     {
       "id": 357,
-      "input": "Write a function to find the maximum element of all the given tuple records.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the maximum element of all the given tuple records.\nYour code should pass this test case: assert find_max([(2, 4), (6, 7), (5, 1), (6, 10), (8, 7)]) == 10",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([(2, 4), (6, 7), (5, 1), (6, 10), (8, 7)]) == 10\n    assert candidate([(3, 5), (7, 8), (6, 2), (7, 11), (9, 8)]) == 11\n    assert candidate([(4, 6), (8, 9), (7, 3), (8, 12), (10, 9)]) == 12\n",
       "language": "python"
     },
     {
       "id": 374,
-      "input": "Write a function to print all permutations of a given string including duplicates.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to print all permutations of a given string including duplicates.\nYour code should pass this test case: assert permute_string('ab')==['ab', 'ba']",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('ab')==['ab', 'ba']\n    assert candidate('abc')==['abc', 'bac', 'bca', 'acb', 'cab', 'cba']\n    assert candidate('abcd')==['abcd', 'bacd', 'bcad', 'bcda', 'acbd', 'cabd', 'cbad', 'cbda', 'acdb', 'cadb', 'cdab', 'cdba', 'abdc', 'badc', 'bdac', 'bdca', 'adbc', 'dabc', 'dbac', 'dbca', 'adcb', 'dacb', 'dcab', 'dcba']\n",
       "language": "python"
     },
     {
       "id": 279,
-      "input": "Write a function to find the nth decagonal number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the nth decagonal number.\nYour code should pass this test case: assert is_num_decagonal(3) == 27",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(3) == 27\n    assert candidate(7) == 175\n    assert candidate(10) == 370\n",
       "language": "python"
     },
     {
       "id": 701,
-      "input": "Write a function to find the equilibrium index of the given array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the equilibrium index of the given array.\nYour code should pass this test case: assert equilibrium_index([1, 2, 3, 4, 1, 2, 3]) == 3",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 2, 3, 4, 1, 2, 3]) == 3\n    assert candidate([-7, 1, 5, 2, -4, 3, 0]) == 3\n    assert candidate([1, 2, 3]) == -1\n",
       "language": "python"
     },
     {
       "id": 69,
-      "input": "Write a function to check whether a list contains the given sublist or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check whether a list contains the given sublist or not.\nYour code should pass this test case: assert is_sublist([2,4,3,5,7],[3,7])==False",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([2,4,3,5,7],[3,7])==False\n    assert candidate([2,4,3,5,7],[4,3])==True\n    assert candidate([2,4,3,5,7],[1,6])==False\n",
       "language": "python"
     },
     {
       "id": 88,
-      "input": "Write a function to get the frequency of the elements in a list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to get the frequency of the elements in a list.\nYour code should pass this test case: assert freq_count([10,10,10,10,20,20,20,20,40,40,50,50,30])==({10: 4, 20: 4, 40: 2, 50: 2, 30: 1}) ",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([10,10,10,10,20,20,20,20,40,40,50,50,30])==({10: 4, 20: 4, 40: 2, 50: 2, 30: 1}) \n    assert candidate([1,2,3,4,3,2,4,1,3,1,4])==({1:3, 2:2,3:3,4:3}) \n    assert candidate([5,6,7,4,9,10,4,5,6,7,9,5])==({10:1,5:3,6:2,7:2,4:2,9:2}) \n",
       "language": "python"
     },
     {
       "id": 170,
-      "input": "Write a function to find sum of the numbers in a list between the indices of a specified range.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find sum of the numbers in a list between the indices of a specified range.\nYour code should pass this test case: assert sum_range_list( [2,1,5,6,8,3,4,9,10,11,8,12],8,10)==29",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate( [2,1,5,6,8,3,4,9,10,11,8,12],8,10)==29\n    assert candidate( [2,1,5,6,8,3,4,9,10,11,8,12],5,7)==16\n    assert candidate( [2,1,5,6,8,3,4,9,10,11,8,12],7,10)==38\n",
       "language": "python"
     },
     {
       "id": 373,
-      "input": "Write a function to find the volume of a cuboid.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the volume of a cuboid.\nYour code should pass this test case: assert volume_cuboid(1,2,3)==6",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(1,2,3)==6\n    assert candidate(5,7,9)==315\n    assert candidate(10,15,21)==3150\n",
       "language": "python"
     },
     {
       "id": 885,
-      "input": "Write a python function to check whether the two given strings are isomorphic to each other or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether the two given strings are isomorphic to each other or not.\nYour code should pass this test case: assert is_Isomorphic(\"paper\",\"title\") == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"paper\",\"title\") == True\n    assert candidate(\"ab\",\"ba\") == True\n    assert candidate(\"ab\",\"aa\") == False\n",
       "language": "python"
     },
     {
       "id": 487,
-      "input": "Write a function to sort a list of tuples in increasing order by the last element in each tuple.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to sort a list of tuples in increasing order by the last element in each tuple.\nYour code should pass this test case: assert sort_tuple([(1, 3), (3, 2), (2, 1)] ) == [(2, 1), (3, 2), (1, 3)]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([(1, 3), (3, 2), (2, 1)] ) == [(2, 1), (3, 2), (1, 3)]\n    assert candidate([(2, 4), (3, 3), (1, 1)] ) == [(1, 1), (3, 3), (2, 4)]\n    assert candidate([(3, 9), (6, 7), (4, 3)] ) == [(4, 3), (6, 7), (3, 9)]\n",
       "language": "python"
     },
     {
       "id": 765,
-      "input": "Write a function to find nth polite number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find nth polite number.\nYour code should pass this test case: assert is_polite(7) == 11",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(7) == 11\n    assert candidate(4) == 7\n    assert candidate(9) == 13\n",
       "language": "python"
     },
     {
       "id": 718,
-      "input": "Write a function to create a list taking alternate elements from another given list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to create a list taking alternate elements from another given list.\nYour code should pass this test case: assert alternate_elements([\"red\", \"black\", \"white\", \"green\", \"orange\"])==['red', 'white', 'orange']",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"])==['red', 'white', 'orange']\n    assert candidate([2, 0, 3, 4, 0, 2, 8, 3, 4, 2])==[2, 3, 0, 8, 4]\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])==[1,3,5,7,9]\n",
       "language": "python"
     },
     {
       "id": 129,
-      "input": "Write a function to calculate magic square.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to calculate magic square.\nYour code should pass this test case: assert magic_square_test([[7, 12, 1, 14], [2, 13, 8, 11], [16, 3, 10, 5], [9, 6, 15, 4]])==True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[7, 12, 1, 14], [2, 13, 8, 11], [16, 3, 10, 5], [9, 6, 15, 4]])==True\n    assert candidate([[2, 7, 6], [9, 5, 1], [4, 3, 8]])==True\n    assert candidate([[2, 7, 6], [9, 5, 1], [4, 3, 7]])==False\n",
       "language": "python"
     },
     {
       "id": 557,
-      "input": "Write a function to toggle characters case in a string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to toggle characters case in a string.\nYour code should pass this test case: assert toggle_string(\"Python\")==(\"pYTHON\")",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"Python\")==(\"pYTHON\")\n    assert candidate(\"Pangram\")==(\"pANGRAM\")\n    assert candidate(\"LIttLE\")==(\"liTTle\")\n",
       "language": "python"
     },
     {
       "id": 573,
-      "input": "Write a python function to calculate the product of the unique numbers of a given list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to calculate the product of the unique numbers of a given list.\nYour code should pass this test case: assert unique_product([10, 20, 30, 40, 20, 50, 60, 40]) ==  720000000",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([10, 20, 30, 40, 20, 50, 60, 40]) ==  720000000\n    assert candidate([1, 2, 3, 1,]) == 6\n    assert candidate([7, 8, 9, 0, 1, 1]) == 0\n",
       "language": "python"
     },
     {
       "id": 240,
-      "input": "Write a function to replace the last element of the list with another list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to replace the last element of the list with another list.\nYour code should pass this test case: assert replace_list([1, 3, 5, 7, 9, 10],[2, 4, 6, 8])==[1, 3, 5, 7, 9, 2, 4, 6, 8]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 3, 5, 7, 9, 10],[2, 4, 6, 8])==[1, 3, 5, 7, 9, 2, 4, 6, 8]\n    assert candidate([1,2,3,4,5],[5,6,7,8])==[1,2,3,4,5,6,7,8]\n    assert candidate([\"red\",\"blue\",\"green\"],[\"yellow\"])==[\"red\",\"blue\",\"yellow\"]\n",
       "language": "python"
     },
     {
       "id": 411,
-      "input": "Write a function to convert the given snake case string to camel case string by using regex.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to convert the given snake case string to camel case string by using regex.\nYour code should pass this test case: assert snake_to_camel('android_tv') == 'AndroidTv'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('android_tv') == 'AndroidTv'\n    assert candidate('google_pixel') == 'GooglePixel'\n    assert candidate('apple_watch') == 'AppleWatch'\n",
       "language": "python"
     },
     {
       "id": 484,
-      "input": "Write a function to remove the matching tuples from the given two tuples.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to remove the matching tuples from the given two tuples.\nYour code should pass this test case: assert remove_matching_tuple([('Hello', 'dude'), ('How', 'are'), ('you', '?')], [('Hello', 'dude'), ('How', 'are')]) == [('you', '?')]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([('Hello', 'dude'), ('How', 'are'), ('you', '?')], [('Hello', 'dude'), ('How', 'are')]) == [('you', '?')]\n    assert candidate([('Part', 'of'), ('the', 'journey'), ('is ', 'end')], [('Journey', 'the'), ('is', 'end')]) == [('Part', 'of'), ('the', 'journey'), ('is ', 'end')]\n    assert candidate([('Its', 'been'), ('a', 'long'), ('day', 'without')], [('a', 'long'), ('my', 'friend')]) == [('Its', 'been'), ('day', 'without')]\n",
       "language": "python"
     },
     {
       "id": 342,
-      "input": "Write a function to find the smallest range that includes at-least one element from each of the given arrays.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the smallest range that includes at-least one element from each of the given arrays.\nYour code should pass this test case: assert find_minimum_range([[3, 6, 8, 10, 15], [1, 5, 12], [4, 8, 15, 16], [2, 6]]) == (4, 6)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[3, 6, 8, 10, 15], [1, 5, 12], [4, 8, 15, 16], [2, 6]]) == (4, 6)\n    assert candidate([[ 2, 3, 4, 8, 10, 15 ], [1, 5, 12], [7, 8, 15, 16], [3, 6]]) == (4, 7)\n    assert candidate([[4, 7, 9, 11, 16], [2, 6, 13], [5, 9, 16, 17], [3, 7]]) == (5, 7)\n",
       "language": "python"
     },
     {
       "id": 309,
-      "input": "Write a python function to find the maximum of two numbers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the maximum of two numbers.\nYour code should pass this test case: assert maximum(5,10) == 10",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(5,10) == 10\n    assert candidate(-1,-2) == -1\n    assert candidate(9,7) == 9\n",
       "language": "python"
     },
     {
       "id": 126,
-      "input": "Write a python function to find the sum of common divisors of two given numbers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the sum of common divisors of two given numbers.\nYour code should pass this test case: assert sum(10,15) == 6",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10,15) == 6\n    assert candidate(100,150) == 93\n    assert candidate(4,6) == 3\n",
       "language": "python"
     },
     {
       "id": 759,
-      "input": "Write a function to check a decimal with a precision of 2.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check a decimal with a precision of 2.\nYour code should pass this test case: assert is_decimal('123.11')==True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('123.11')==True\n    assert candidate('e666.86')==False\n    assert candidate('3.124587')==False\n",
       "language": "python"
     },
     {
       "id": 961,
-      "input": "Write a function to convert a roman numeral to an integer.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to convert a roman numeral to an integer.\nYour code should pass this test case: assert roman_to_int('MMMCMLXXXVI')==3986",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('MMMCMLXXXVI')==3986\n    assert candidate('MMMM')==4000\n    assert candidate('C')==100\n",
       "language": "python"
     },
     {
       "id": 87,
-      "input": "Write a function to merge three dictionaries into a single expression.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to merge three dictionaries into a single expression.\nYour code should pass this test case: assert merge_dictionaries_three({ \"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\" }, { \"G\": \"Green\", \"W\": \"White\" },{ \"O\": \"Orange\", \"W\": \"White\", \"B\": \"Black\" })=={'B': 'Black', 'R': 'Red', 'P': 'Pink', 'G': 'Green', 'W': 'White', 'O': 'Orange'}",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate({ \"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\" }, { \"G\": \"Green\", \"W\": \"White\" },{ \"O\": \"Orange\", \"W\": \"White\", \"B\": \"Black\" })=={'B': 'Black', 'R': 'Red', 'P': 'Pink', 'G': 'Green', 'W': 'White', 'O': 'Orange'}\n    assert candidate({ \"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\" }, { \"G\": \"Green\", \"W\": \"White\" },{\"L\":\"lavender\",\"B\":\"Blue\"})=={'W': 'White', 'P': 'Pink', 'B': 'Black', 'R': 'Red', 'G': 'Green', 'L': 'lavender'}\n    assert candidate({ \"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\" },{\"L\":\"lavender\",\"B\":\"Blue\"},{ \"G\": \"Green\", \"W\": \"White\" })=={'B': 'Black', 'P': 'Pink', 'R': 'Red', 'G': 'Green', 'L': 'lavender', 'W': 'White'}\n",
       "language": "python"
     },
     {
       "id": 630,
-      "input": "Write a function to extract all the adjacent coordinates of the given coordinate tuple.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to extract all the adjacent coordinates of the given coordinate tuple.\nYour code should pass this test case: assert get_coordinates((3, 4)) == [[2, 3], [2, 4], [2, 5], [3, 3], [3, 4], [3, 5], [4, 3], [4, 4], [4, 5]]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((3, 4)) == [[2, 3], [2, 4], [2, 5], [3, 3], [3, 4], [3, 5], [4, 3], [4, 4], [4, 5]]\n    assert candidate((4, 5)) ==[[3, 4], [3, 5], [3, 6], [4, 4], [4, 5], [4, 6], [5, 4], [5, 5], [5, 6]]\n    assert candidate((5, 6)) == [[4, 5], [4, 6], [4, 7], [5, 5], [5, 6], [5, 7], [6, 5], [6, 6], [6, 7]]\n",
       "language": "python"
     },
     {
       "id": 774,
-      "input": "Write a function to check if the string is a valid email address or not using regex.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check if the string is a valid email address or not using regex.\nYour code should pass this test case: assert check_email(\"ankitrai326@gmail.com\") == 'Valid Email'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"ankitrai326@gmail.com\") == 'Valid Email'\n    assert candidate(\"my.ownsite@ourearth.org\") == 'Valid Email'\n    assert candidate(\"ankitaoie326.com\") == 'Invalid Email'\n",
       "language": "python"
     },
     {
       "id": 687,
-      "input": "Write a function to find the greatest common divisor (gcd) of two integers by using recursion.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the greatest common divisor (gcd) of two integers by using recursion.\nYour code should pass this test case: assert recur_gcd(12,14) == 2",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(12,14) == 2\n    assert candidate(13,17) == 1\n    assert candidate(9, 3) == 3\n",
       "language": "python"
     },
     {
       "id": 680,
-      "input": "Write a python function to check whether a sequence of numbers has an increasing trend or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether a sequence of numbers has an increasing trend or not.\nYour code should pass this test case: assert increasing_trend([1,2,3,4]) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,3,4]) == True\n    assert candidate([4,3,2,1]) == False\n    assert candidate([0,1,4,9]) == True\n",
       "language": "python"
     },
     {
       "id": 808,
-      "input": "Write a function to check if the given tuples contain the k or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check if the given tuples contain the k or not.\nYour code should pass this test case: assert check_K((10, 4, 5, 6, 8), 6) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((10, 4, 5, 6, 8), 6) == True\n    assert candidate((1, 2, 3, 4, 5, 6), 7) == False\n    assert candidate((7, 8, 9, 44, 11, 12), 11) == True\n",
       "language": "python"
     },
     {
       "id": 307,
-      "input": "Write a function to get a colon of a tuple.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to get a colon of a tuple.\nYour code should pass this test case: assert colon_tuplex((\"HELLO\", 5, [], True) ,2,50)==(\"HELLO\", 5, [50], True) ",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((\"HELLO\", 5, [], True) ,2,50)==(\"HELLO\", 5, [50], True) \n    assert candidate((\"HELLO\", 5, [], True) ,2,100)==((\"HELLO\", 5, [100],True))\n    assert candidate((\"HELLO\", 5, [], True) ,2,500)==(\"HELLO\", 5, [500], True)\n",
       "language": "python"
     },
     {
       "id": 746,
-      "input": "Write a function to find area of a sector.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find area of a sector.\nYour code should pass this test case: assert sector_area(4,45)==6.285714285714286",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(4,45)==6.285714285714286\n    assert candidate(9,45)==31.82142857142857\n    assert candidate(9,360)==None\n",
       "language": "python"
     },
     {
       "id": 757,
-      "input": "Write a function to count the pairs of reverse strings in the given string list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to count the pairs of reverse strings in the given string list.\nYour code should pass this test case: assert count_reverse_pairs([\"julia\", \"best\", \"tseb\", \"for\", \"ailuj\"])== '2'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([\"julia\", \"best\", \"tseb\", \"for\", \"ailuj\"])== '2'\n    assert candidate([\"geeks\", \"best\", \"for\", \"skeeg\"]) == '1'\n    assert candidate([\"makes\", \"best\", \"sekam\", \"for\", \"rof\"]) == '2' \n",
       "language": "python"
     },
     {
       "id": 676,
-      "input": "Write a function to remove everything except alphanumeric characters from the given string by using regex.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to remove everything except alphanumeric characters from the given string by using regex.\nYour code should pass this test case: assert remove_extra_char('**//Google Android// - 12. ') == 'GoogleAndroid12'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('**//Google Android// - 12. ') == 'GoogleAndroid12'\n    assert candidate('****//Google Flutter//*** - 36. ') == 'GoogleFlutter36'\n    assert candidate('**//Google Firebase// - 478. ') == 'GoogleFirebase478'\n",
       "language": "python"
     },
     {
       "id": 857,
-      "input": "Write a function to list out the list of given strings individually using map function.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to list out the list of given strings individually using map function.\nYour code should pass this test case: assert listify_list(['Red', 'Blue', 'Black', 'White', 'Pink'])==[['R', 'e', 'd'], ['B', 'l', 'u', 'e'], ['B', 'l', 'a', 'c', 'k'], ['W', 'h', 'i', 't', 'e'], ['P', 'i', 'n', 'k']]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(['Red', 'Blue', 'Black', 'White', 'Pink'])==[['R', 'e', 'd'], ['B', 'l', 'u', 'e'], ['B', 'l', 'a', 'c', 'k'], ['W', 'h', 'i', 't', 'e'], ['P', 'i', 'n', 'k']]\n    assert candidate(['python'])==[['p', 'y', 't', 'h', 'o', 'n']]\n    assert candidate([' red ', 'green',' black', 'blue ',' orange', 'brown'])==[[' ', 'r', 'e', 'd', ' '], ['g', 'r', 'e', 'e', 'n'], [' ', 'b', 'l', 'a', 'c', 'k'], ['b', 'l', 'u', 'e', ' '], [' ', 'o', 'r', 'a', 'n', 'g', 'e'], ['b', 'r', 'o', 'w', 'n']]\n",
       "language": "python"
     },
     {
       "id": 469,
-      "input": "Write a function to find the maximum profit earned from a maximum of k stock transactions",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the maximum profit earned from a maximum of k stock transactions\nYour code should pass this test case: assert max_profit([1, 5, 2, 3, 7, 6, 4, 5], 3) == 10",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 5, 2, 3, 7, 6, 4, 5], 3) == 10\n    assert candidate([2, 4, 7, 5, 4, 3, 5], 2) == 7\n    assert candidate([10, 6, 8, 4, 2], 2) == 2\n",
       "language": "python"
     },
     {
       "id": 305,
-      "input": "Write a function to match two words from a list of words starting with letter 'p'.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to match two words from a list of words starting with letter 'p'.\nYour code should pass this test case: assert start_withp([\"Python PHP\", \"Java JavaScript\", \"c c++\"])==('Python', 'PHP')",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([\"Python PHP\", \"Java JavaScript\", \"c c++\"])==('Python', 'PHP')\n    assert candidate([\"Python Programming\",\"Java Programming\"])==('Python','Programming')\n    assert candidate([\"Pqrst Pqr\",\"qrstuv\"])==('Pqrst','Pqr')\n",
       "language": "python"
     },
     {
       "id": 609,
-      "input": "Write a python function to find minimum possible value for the given periodic function.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find minimum possible value for the given periodic function.\nYour code should pass this test case: assert floor_Min(10,20,30) == 15",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10,20,30) == 15\n    assert candidate(1,2,1) == 0\n    assert candidate(11,10,9) == 9\n",
       "language": "python"
     },
     {
       "id": 369,
-      "input": "Write a function to find the lateral surface area of cuboid",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the lateral surface area of cuboid\nYour code should pass this test case: assert lateralsurface_cuboid(8,5,6)==156",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(8,5,6)==156\n    assert candidate(7,9,10)==320\n    assert candidate(10,20,30)==1800\n",
       "language": "python"
     },
     {
       "id": 282,
-      "input": "Write a function to substaract two lists using map and lambda function.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to substaract two lists using map and lambda function.\nYour code should pass this test case: assert sub_list([1, 2, 3],[4,5,6])==[-3,-3,-3]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 2, 3],[4,5,6])==[-3,-3,-3]\n    assert candidate([1,2],[3,4])==[-2,-2]\n    assert candidate([90,120],[50,70])==[40,50]\n",
       "language": "python"
     },
     {
       "id": 50,
-      "input": "Write a function to find the list with minimum length using lambda function.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the list with minimum length using lambda function.\nYour code should pass this test case: assert min_length_list([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]])==(1, [0])",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]])==(1, [0])\n    assert candidate([[1,2,3,4,5],[1,2,3,4],[1,2,3],[1,2],[1]])==(1,[1])\n    assert candidate([[3,4,5],[6,7,8,9],[10,11,12],[1,2]])==(2,[1,2])\n",
       "language": "python"
     },
     {
       "id": 853,
-      "input": "Write a python function to find sum of odd factors of a number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find sum of odd factors of a number.\nYour code should pass this test case: assert sum_of_odd_Factors(30) == 24",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(30) == 24\n    assert candidate(18) == 13\n    assert candidate(2) == 1\n",
       "language": "python"
     },
     {
       "id": 734,
-      "input": "Write a python function to find sum of products of all possible subarrays.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find sum of products of all possible subarrays.\nYour code should pass this test case: assert sum_Of_Subarray_Prod([1,2,3],3) == 20",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,3],3) == 20\n    assert candidate([1,2],2) == 5\n    assert candidate([1,2,3,4],4) == 84\n",
       "language": "python"
     },
     {
       "id": 214,
-      "input": "Write a function to convert radians to degrees.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to convert radians to degrees.\nYour code should pass this test case: assert degree_radian(90)==5156.620156177409",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(90)==5156.620156177409\n    assert candidate(60)==3437.746770784939\n    assert candidate(120)==6875.493541569878\n",
       "language": "python"
     },
     {
       "id": 461,
-      "input": "Write a python function to count the upper case characters in a given string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count the upper case characters in a given string.\nYour code should pass this test case: assert upper_ctr('PYthon') == 1",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('PYthon') == 1\n    assert candidate('BigData') == 1\n    assert candidate('program') == 0\n",
       "language": "python"
     },
     {
       "id": 720,
-      "input": "Write a function to add a dictionary to the tuple.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to add a dictionary to the tuple.\nYour code should pass this test case: assert add_dict_to_tuple((4, 5, 6), {\"MSAM\" : 1, \"is\" : 2, \"best\" : 3} ) == (4, 5, 6, {'MSAM': 1, 'is': 2, 'best': 3})",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((4, 5, 6), {\"MSAM\" : 1, \"is\" : 2, \"best\" : 3} ) == (4, 5, 6, {'MSAM': 1, 'is': 2, 'best': 3})\n    assert candidate((1, 2, 3), {\"UTS\" : 2, \"is\" : 3, \"Worst\" : 4} ) == (1, 2, 3, {'UTS': 2, 'is': 3, 'Worst': 4})\n    assert candidate((8, 9, 10), {\"POS\" : 3, \"is\" : 4, \"Okay\" : 5} ) == (8, 9, 10, {'POS': 3, 'is': 4, 'Okay': 5})\n",
       "language": "python"
     },
     {
       "id": 597,
-      "input": "Write a function to find kth element from the given two sorted arrays.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find kth element from the given two sorted arrays.\nYour code should pass this test case: assert find_kth([2, 3, 6, 7, 9], [1, 4, 8, 10], 5, 4, 5) == 6",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([2, 3, 6, 7, 9], [1, 4, 8, 10], 5, 4, 5) == 6\n    assert candidate([100, 112, 256, 349, 770], [72, 86, 113, 119, 265, 445, 892], 5, 7, 7) == 256\n    assert candidate([3, 4, 7, 8, 10], [2, 5, 9, 11], 5, 4, 6) == 8\n",
       "language": "python"
     },
     {
       "id": 530,
-      "input": "Write a function to find the ration of negative numbers in an array of integers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the ration of negative numbers in an array of integers.\nYour code should pass this test case: assert negative_count([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8])==0.31",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8])==0.31\n    assert candidate([2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8])==0.31\n    assert candidate([2, 4, -6, -9, 11, -12, 14, -5, 17])==0.44\n",
       "language": "python"
     },
     {
       "id": 13,
-      "input": "Write a function to count the most common words in a dictionary.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to count the most common words in a dictionary.\nYour code should pass this test case: assert count_common(['red','green','black','pink','black','white','black','eyes','white','black','orange','pink','pink','red','red','white','orange','white',\"black\",'pink','green','green','pink','green','pink','white','orange',\"orange\",'red']) == [('pink', 6), ('black', 5), ('white', 5), ('red', 4)]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(['red','green','black','pink','black','white','black','eyes','white','black','orange','pink','pink','red','red','white','orange','white',\"black\",'pink','green','green','pink','green','pink','white','orange',\"orange\",'red']) == [('pink', 6), ('black', 5), ('white', 5), ('red', 4)]\n    assert candidate(['one', 'two', 'three', 'four', 'five', 'one', 'two', 'one', 'three', 'one']) == [('one', 4), ('two', 2), ('three', 2), ('four', 1)]\n    assert candidate(['Facebook', 'Apple', 'Amazon', 'Netflix', 'Google', 'Apple', 'Netflix', 'Amazon']) == [('Apple', 2), ('Amazon', 2), ('Netflix', 2), ('Facebook', 1)]\n",
       "language": "python"
     },
     {
       "id": 559,
-      "input": "Write a function to find the largest sum of contiguous subarray in the given array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the largest sum of contiguous subarray in the given array.\nYour code should pass this test case: assert max_sub_array_sum([-2, -3, 4, -1, -2, 1, 5, -3], 8) == 7",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([-2, -3, 4, -1, -2, 1, 5, -3], 8) == 7\n    assert candidate([-3, -4, 5, -2, -3, 2, 6, -4], 8) == 8\n    assert candidate([-4, -5, 6, -3, -4, 3, 7, -5], 8) == 10\n",
       "language": "python"
     },
     {
       "id": 187,
-      "input": "Write a function to find the longest common subsequence for the given two sequences.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the longest common subsequence for the given two sequences.\nYour code should pass this test case: assert longest_common_subsequence(\"AGGTAB\" , \"GXTXAYB\", 6, 7) == 4",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"AGGTAB\" , \"GXTXAYB\", 6, 7) == 4\n    assert candidate(\"ABCDGH\" , \"AEDFHR\", 6, 6) == 3\n    assert candidate(\"AXYT\" , \"AYZX\", 4, 4) == 2\n",
       "language": "python"
     },
     {
       "id": 185,
-      "input": "Write a function to find the focus of a parabola.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the focus of a parabola.\nYour code should pass this test case: assert parabola_focus(5,3,2)==(-0.3, 1.6)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(5,3,2)==(-0.3, 1.6)\n    assert candidate(9,8,4)==(-0.4444444444444444, 2.25)\n    assert candidate(2,4,6)==(-1.0, 4.125)\n",
       "language": "python"
     },
     {
       "id": 900,
-      "input": "Write a function where a string will start with a specific number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function where a string will start with a specific number.\nYour code should pass this test case: assert match_num('5-2345861')==True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('5-2345861')==True\n    assert candidate('6-2345861')==False\n    assert candidate('78910')==False\n",
       "language": "python"
     },
     {
       "id": 7,
-      "input": "Write a function to find all words which are at least 4 characters long in a string by using regex.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find all words which are at least 4 characters long in a string by using regex.\nYour code should pass this test case: assert find_char_long('Please move back to stream') == ['Please', 'move', 'back', 'stream']",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('Please move back to stream') == ['Please', 'move', 'back', 'stream']\n    assert candidate('Jing Eco and Tech') == ['Jing', 'Tech']\n    assert candidate('Jhingai wulu road Zone 3') == ['Jhingai', 'wulu', 'road', 'Zone']\n",
       "language": "python"
     },
     {
       "id": 549,
-      "input": "Write a python function to find the sum of fifth power of first n odd natural numbers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the sum of fifth power of first n odd natural numbers.\nYour code should pass this test case: assert odd_Num_Sum(1) == 1",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(1) == 1\n    assert candidate(2) == 244\n    assert candidate(3) == 3369\n",
       "language": "python"
     },
     {
       "id": 163,
-      "input": "Write a function to calculate the area of a regular polygon.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to calculate the area of a regular polygon.\nYour code should pass this test case: assert area_polygon(4,20)==400.00000000000006",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(4,20)==400.00000000000006\n    assert candidate(10,15)==1731.1969896610804\n    assert candidate(9,7)==302.90938549487214\n",
       "language": "python"
     },
     {
       "id": 311,
-      "input": "Write a python function to set the left most unset bit.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to set the left most unset bit.\nYour code should pass this test case: assert set_left_most_unset_bit(10) == 14",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10) == 14\n    assert candidate(12) == 14\n    assert candidate(15) == 15\n",
       "language": "python"
     },
     {
       "id": 184,
-      "input": "Write a function to find all the values in a list that are greater than a specified number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find all the values in a list that are greater than a specified number.\nYour code should pass this test case: assert greater_specificnum([220, 330, 500],200)==True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([220, 330, 500],200)==True\n    assert candidate([12, 17, 21],20)==False\n    assert candidate([1,2,3,4],10)==False\n",
       "language": "python"
     },
     {
       "id": 200,
-      "input": "Write a function to find all index positions of the maximum values in a given list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find all index positions of the maximum values in a given list.\nYour code should pass this test case: assert position_max([12,33,23,10,67,89,45,667,23,12,11,10,54])==[7]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([12,33,23,10,67,89,45,667,23,12,11,10,54])==[7]\n    assert candidate([1,2,2,2,4,4,4,5,5,5,5])==[7,8,9,10]\n    assert candidate([2,1,5,6,8,3,4,9,10,11,8,12])==[11]\n",
       "language": "python"
     },
     {
       "id": 683,
-      "input": "Write a python function to check whether the given number can be represented by sum of two squares or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether the given number can be represented by sum of two squares or not.\nYour code should pass this test case: assert sum_Square(25) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(25) == True\n    assert candidate(24) == False\n    assert candidate(17) == True\n",
       "language": "python"
     },
     {
       "id": 189,
-      "input": "Write a python function to find the first missing positive number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the first missing positive number.\nYour code should pass this test case: assert first_Missing_Positive([1,2,3,-1,5],5) == 4",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,3,-1,5],5) == 4\n    assert candidate([0,-1,-2,1,5,8],6) == 2\n    assert candidate([0,1,2,5,-8],5) == 3\n",
       "language": "python"
     },
     {
       "id": 224,
-      "input": "Write a python function to count set bits of a given number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count set bits of a given number.\nYour code should pass this test case: assert count_Set_Bits(2) == 1",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(2) == 1\n    assert candidate(4) == 1\n    assert candidate(6) == 2\n",
       "language": "python"
     },
     {
       "id": 55,
-      "input": "Write a function to find t-nth term of geometric series.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find t-nth term of geometric series.\nYour code should pass this test case: assert tn_gp(1,5,2)==16",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(1,5,2)==16\n    assert candidate(1,5,4)==256\n    assert candidate(2,6,3)==486\n",
       "language": "python"
     },
     {
       "id": 706,
-      "input": "Write a function to find whether an array is subset of another array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find whether an array is subset of another array.\nYour code should pass this test case: assert is_subset([11, 1, 13, 21, 3, 7], 6, [11, 3, 7, 1], 4) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([11, 1, 13, 21, 3, 7], 6, [11, 3, 7, 1], 4) == True\n    assert candidate([1, 2, 3, 4, 5, 6], 6, [1, 2, 4], 3) == True\n    assert candidate([10, 5, 2, 23, 19], 5, [19, 5, 3], 3) == False\n",
       "language": "python"
     },
     {
       "id": 280,
-      "input": "Write a function to search an element in the given array by using sequential search.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to search an element in the given array by using sequential search.\nYour code should pass this test case: assert sequential_search([11,23,58,31,56,77,43,12,65,19],31) == (True, 3)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([11,23,58,31,56,77,43,12,65,19],31) == (True, 3)\n    assert candidate([12, 32, 45, 62, 35, 47, 44, 61],61) == (True, 7)\n    assert candidate([9, 10, 17, 19, 22, 39, 48, 56],48) == (True, 6)\n",
       "language": "python"
     },
     {
       "id": 806,
-      "input": "Write a function to find maximum run of uppercase characters in the given string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find maximum run of uppercase characters in the given string.\nYour code should pass this test case: assert max_run_uppercase('GeMKSForGERksISBESt') == 5",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('GeMKSForGERksISBESt') == 5\n    assert candidate('PrECIOusMOVemENTSYT') == 6\n    assert candidate('GooGLEFluTTER') == 4\n",
       "language": "python"
     },
     {
       "id": 348,
-      "input": "Write a function to count sequences of given length having non-negative prefix sums that can be generated by given values.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to count sequences of given length having non-negative prefix sums that can be generated by given values.\nYour code should pass this test case: assert find_ways(4) == 2",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(4) == 2\n    assert candidate(6) == 5\n    assert candidate(8) == 14\n",
       "language": "python"
     },
     {
       "id": 641,
-      "input": "Write a function to find the nth nonagonal number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the nth nonagonal number.\nYour code should pass this test case: assert is_nonagonal(10) == 325",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10) == 325\n    assert candidate(15) == 750\n    assert candidate(18) == 1089\n",
       "language": "python"
     },
     {
       "id": 715,
-      "input": "Write a function to convert the given string of integers into a tuple.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to convert the given string of integers into a tuple.\nYour code should pass this test case: assert str_to_tuple(\"1, -5, 4, 6, 7\") == (1, -5, 4, 6, 7)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"1, -5, 4, 6, 7\") == (1, -5, 4, 6, 7)\n    assert candidate(\"1, 2, 3, 4, 5\") == (1, 2, 3, 4, 5)\n    assert candidate(\"4, 6, 9, 11, 13, 14\") == (4, 6, 9, 11, 13, 14)\n",
       "language": "python"
     },
     {
       "id": 332,
-      "input": "Write a function to count character frequency of a given string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to count character frequency of a given string.\nYour code should pass this test case: assert char_frequency('python')=={'p': 1, 'y': 1, 't': 1, 'h': 1, 'o': 1, 'n': 1}",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('python')=={'p': 1, 'y': 1, 't': 1, 'h': 1, 'o': 1, 'n': 1}\n    assert candidate('program')=={'p': 1, 'r': 2, 'o': 1, 'g': 1, 'a': 1, 'm': 1}\n    assert candidate('language')=={'l': 1, 'a': 2, 'n': 1, 'g': 2, 'u': 1, 'e': 1}\n",
       "language": "python"
     },
     {
       "id": 909,
-      "input": "Write a function to find the previous palindrome of a specified number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the previous palindrome of a specified number.\nYour code should pass this test case: assert previous_palindrome(99)==88",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(99)==88\n    assert candidate(1221)==1111\n    assert candidate(120)==111\n",
       "language": "python"
     },
     {
       "id": 419,
-      "input": "Write a function to round every number of a given list of numbers and print the total sum multiplied by the length of the list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to round every number of a given list of numbers and print the total sum multiplied by the length of the list.\nYour code should pass this test case: assert round_and_sum([22.4, 4.0, -16.22, -9.10, 11.00, -12.22, 14.20, -5.20, 17.50])==243",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([22.4, 4.0, -16.22, -9.10, 11.00, -12.22, 14.20, -5.20, 17.50])==243\n    assert candidate([5,2,9,24.3,29])==345\n    assert candidate([25.0,56.7,89.2])==513\n",
       "language": "python"
     },
     {
       "id": 665,
-      "input": "Write a python function to shift first element to the end of given list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to shift first element to the end of given list.\nYour code should pass this test case: assert move_last([1,2,3,4]) == [2,3,4,1]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,3,4]) == [2,3,4,1]\n    assert candidate([2,3,4,1,5,0]) == [3,4,1,5,0,2]\n    assert candidate([5,4,3,2,1]) == [4,3,2,1,5]\n",
       "language": "python"
     },
     {
       "id": 631,
-      "input": "Write a function to replace whitespaces with an underscore and vice versa in a given string by using regex.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to replace whitespaces with an underscore and vice versa in a given string by using regex.\nYour code should pass this test case: assert replace_spaces('Jumanji The Jungle') == 'Jumanji_The_Jungle'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('Jumanji The Jungle') == 'Jumanji_The_Jungle'\n    assert candidate('The Avengers') == 'The_Avengers'\n    assert candidate('Fast and Furious') == 'Fast_and_Furious'\n",
       "language": "python"
     },
     {
       "id": 873,
-      "input": "Write a function to solve the fibonacci sequence using recursion.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to solve the fibonacci sequence using recursion.\nYour code should pass this test case: assert fibonacci(7) == 13",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(7) == 13\n    assert candidate(8) == 21\n    assert candidate(9) == 34\n",
       "language": "python"
     },
     {
       "id": 143,
-      "input": "Write a function to find number of lists present in the given tuple.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find number of lists present in the given tuple.\nYour code should pass this test case: assert find_lists(([1, 2, 3, 4], [5, 6, 7, 8])) == 2",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(([1, 2, 3, 4], [5, 6, 7, 8])) == 2\n    assert candidate(([1, 2], [3, 4], [5, 6]))  == 3\n    assert candidate(([9, 8, 7, 6, 5, 4, 3, 2, 1])) == 1\n",
       "language": "python"
     },
     {
       "id": 756,
-      "input": "Write a function that matches a string that has an a followed by zero or one 'b'.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function that matches a string that has an a followed by zero or one 'b'.\nYour code should pass this test case: assert text_match_zero_one(\"ac\")==('Found a match!')",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"ac\")==('Found a match!')\n    assert candidate(\"dc\")==('Not matched!')\n    assert candidate(\"abbbba\")==('Found a match!')\n",
       "language": "python"
     },
     {
       "id": 521,
-      "input": "Write a function to print check if the triangle is scalene or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to print check if the triangle is scalene or not.\nYour code should pass this test case: assert check_isosceles(6,8,12)==True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(6,8,12)==True\n    assert candidate(6,6,12)==False\n    assert candidate(6,15,20)==True\n",
       "language": "python"
     },
     {
       "id": 112,
-      "input": "Write a python function to find the perimeter of a cylinder.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the perimeter of a cylinder.\nYour code should pass this test case: assert perimeter(2,4) == 12",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(2,4) == 12\n    assert candidate(1,2) == 6\n    assert candidate(3,1) == 8\n",
       "language": "python"
     },
     {
       "id": 619,
-      "input": "Write a function to move all the numbers in it to the given string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to move all the numbers in it to the given string.\nYour code should pass this test case: assert move_num('I1love143you55three3000thousand') == 'Iloveyouthreethousand1143553000'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('I1love143you55three3000thousand') == 'Iloveyouthreethousand1143553000'\n    assert candidate('Avengers124Assemble') == 'AvengersAssemble124'\n    assert candidate('Its11our12path13to14see15things16do17things') == 'Itsourpathtoseethingsdothings11121314151617'\n",
       "language": "python"
     },
     {
       "id": 18,
-      "input": "Write a function to remove characters from the first string which are present in the second string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to remove characters from the first string which are present in the second string.\nYour code should pass this test case: assert remove_dirty_chars(\"probasscurve\", \"pros\") == 'bacuve'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"probasscurve\", \"pros\") == 'bacuve'\n    assert candidate(\"digitalindia\", \"talent\") == 'digiidi'\n    assert candidate(\"exoticmiles\", \"toxic\") == 'emles' \n",
       "language": "python"
     },
     {
       "id": 169,
-      "input": "Write a function to calculate the nth pell number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to calculate the nth pell number.\nYour code should pass this test case: assert get_pell(4) == 12",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(4) == 12\n    assert candidate(7) == 169\n    assert candidate(8) == 408\n",
       "language": "python"
     },
     {
       "id": 822,
-      "input": "Write a function to return true if the password is valid.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to return true if the password is valid.\nYour code should pass this test case: assert pass_validity(\"password\")==False",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"password\")==False\n    assert candidate(\"Password@10\")==True\n    assert candidate(\"password@10\")==False\n",
       "language": "python"
     },
     {
       "id": 242,
-      "input": "Write a function to count total characters in a string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to count total characters in a string.\nYour code should pass this test case: assert count_charac(\"python programming\")==18",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"python programming\")==18\n    assert candidate(\"language\")==8\n    assert candidate(\"words\")==5\n",
       "language": "python"
     },
     {
       "id": 558,
-      "input": "Write a python function to find the digit distance between two integers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the digit distance between two integers.\nYour code should pass this test case: assert digit_distance_nums(1,2) == 1",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(1,2) == 1\n    assert candidate(23,56) == 6\n    assert candidate(123,256) == 7\n",
       "language": "python"
     },
     {
       "id": 453,
-      "input": "Write a python function to find the sum of even factors of a number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the sum of even factors of a number.\nYour code should pass this test case: assert sumofFactors(18) == 26",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(18) == 26\n    assert candidate(30) == 48\n    assert candidate(6) == 8\n",
       "language": "python"
     },
     {
       "id": 869,
-      "input": "Write a function to remove sublists from a given list of lists, which are outside a given range.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to remove sublists from a given list of lists, which are outside a given range.\nYour code should pass this test case: assert remove_list_range([[2], [0], [1, 2, 3], [0, 1, 2, 3, 6, 7], [9, 11], [13, 14, 15, 17]],13,17)==[[13, 14, 15, 17]]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[2], [0], [1, 2, 3], [0, 1, 2, 3, 6, 7], [9, 11], [13, 14, 15, 17]],13,17)==[[13, 14, 15, 17]]\n    assert candidate([[2], [0], [1, 2, 3], [0, 1, 2, 3, 6, 7], [9, 11], [13, 14, 15, 17]],1,3)==[[2], [1, 2, 3]]\n    assert candidate([[2], [0], [1, 2, 3], [0, 1, 2, 3, 6, 7], [9, 11], [13, 14, 15, 17]],0,7)==[[2], [0], [1, 2, 3], [0, 1, 2, 3, 6, 7]]\n",
       "language": "python"
     },
     {
       "id": 161,
-      "input": "Write a function to remove all elements from a given list present in another list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to remove all elements from a given list present in another list.\nYour code should pass this test case: assert remove_elements([1,2,3,4,5,6,7,8,9,10],[2,4,6,8])==[1, 3, 5, 7, 9, 10]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,3,4,5,6,7,8,9,10],[2,4,6,8])==[1, 3, 5, 7, 9, 10]\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10],[1, 3, 5, 7])==[2, 4, 6, 8, 9, 10]\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10],[5,7])==[1, 2, 3, 4, 6, 8, 9, 10]\n",
       "language": "python"
     },
     {
       "id": 131,
-      "input": "Write a python function to reverse only the vowels of a given string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to reverse only the vowels of a given string.\nYour code should pass this test case: assert reverse_vowels(\"Python\") == \"Python\"",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"Python\") == \"Python\"\n    assert candidate(\"USA\") == \"ASU\"\n    assert candidate(\"ab\") == \"ab\"\n",
       "language": "python"
     },
     {
       "id": 817,
-      "input": "Write a function to find numbers divisible by m or n from a list of numbers using lambda function.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find numbers divisible by m or n from a list of numbers using lambda function.\nYour code should pass this test case: assert div_of_nums([19, 65, 57, 39, 152, 639, 121, 44, 90, 190],19,13)==[19, 65, 57, 39, 152, 190]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([19, 65, 57, 39, 152, 639, 121, 44, 90, 190],19,13)==[19, 65, 57, 39, 152, 190]\n    assert candidate([1, 2, 3, 5, 7, 8, 10],2,5)==[2, 5, 8, 10]\n    assert candidate([10,15,14,13,18,12,20],10,5)==[10, 15, 20]\n",
       "language": "python"
     },
     {
       "id": 180,
-      "input": "Write a function to calculate distance between two points using latitude and longitude.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to calculate distance between two points using latitude and longitude.\nYour code should pass this test case: assert distance_lat_long(23.5,67.5,25.5,69.5)==12179.372041317429",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(23.5,67.5,25.5,69.5)==12179.372041317429\n    assert candidate(10.5,20.5,30.5,40.5)==6069.397933300514\n    assert candidate(10,20,30,40)==6783.751974994595\n",
       "language": "python"
     },
     {
       "id": 432,
-      "input": "Write a function to find the median of a trapezium.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the median of a trapezium.\nYour code should pass this test case: assert median_trapezium(15,25,35)==20",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(15,25,35)==20\n    assert candidate(10,20,30)==15\n    assert candidate(6,9,4)==7.5\n",
       "language": "python"
     },
     {
       "id": 273,
-      "input": "Write a function to substract the contents of one tuple with corresponding index of other tuple.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to substract the contents of one tuple with corresponding index of other tuple.\nYour code should pass this test case: assert substract_elements((10, 4, 5), (2, 5, 18)) == (8, -1, -13)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((10, 4, 5), (2, 5, 18)) == (8, -1, -13)\n    assert candidate((11, 2, 3), (24, 45 ,16)) == (-13, -43, -13)\n    assert candidate((7, 18, 9), (10, 11, 12)) == (-3, 7, -3)\n",
       "language": "python"
     },
     {
       "id": 92,
-      "input": "Write a function to check whether the given number is undulating or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check whether the given number is undulating or not.\nYour code should pass this test case: assert is_undulating(\"1212121\") == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"1212121\") == True\n    assert candidate(\"1991\") == False\n    assert candidate(\"121\") == True\n",
       "language": "python"
     },
     {
       "id": 618,
-      "input": "Write a function to divide two lists using map and lambda function.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to divide two lists using map and lambda function.\nYour code should pass this test case: assert div_list([4,5,6],[1, 2, 3])==[4.0,2.5,2.0]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([4,5,6],[1, 2, 3])==[4.0,2.5,2.0]\n    assert candidate([3,2],[1,4])==[3.0, 0.5]\n    assert candidate([90,120],[50,70])==[1.8, 1.7142857142857142]\n",
       "language": "python"
     },
     {
       "id": 121,
-      "input": "Write a function to find the triplet with sum of the given array",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the triplet with sum of the given array\nYour code should pass this test case: assert check_triplet([2, 7, 4, 0, 9, 5, 1, 3], 8, 6, 0) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([2, 7, 4, 0, 9, 5, 1, 3], 8, 6, 0) == True\n    assert candidate([1, 4, 5, 6, 7, 8, 5, 9], 8, 6, 0) == False\n    assert candidate([10, 4, 2, 3, 5], 5, 15, 0) == True\n",
       "language": "python"
     },
     {
       "id": 239,
-      "input": "Write a function to find the number of possible sequences of length n such that each of the next element is greater than or equal to twice of the previous element but less than or equal to m.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the number of possible sequences of length n such that each of the next element is greater than or equal to twice of the previous element but less than or equal to m.\nYour code should pass this test case: assert get_total_number_of_sequences(10, 4) == 4",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10, 4) == 4\n    assert candidate(5, 2) == 6\n    assert candidate(16, 3) == 84\n",
       "language": "python"
     },
     {
       "id": 948,
-      "input": "Write a function to get an item of a tuple.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to get an item of a tuple.\nYour code should pass this test case: assert get_item((\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"),3)==('e')",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"),3)==('e')\n    assert candidate((\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"),-4)==('u')\n    assert candidate((\"w\", 3, \"r\", \"e\", \"s\", \"o\", \"u\", \"r\", \"c\", \"e\"),-3)==('r')\n",
       "language": "python"
     },
     {
       "id": 625,
-      "input": "Write a python function to interchange first and last elements in a given list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to interchange first and last elements in a given list.\nYour code should pass this test case: assert swap_List([1,2,3]) == [3,2,1]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,3]) == [3,2,1]\n    assert candidate([1,2,3,4,4]) == [4,2,3,4,1]\n    assert candidate([4,5,6]) == [6,5,4]\n",
       "language": "python"
     },
     {
       "id": 454,
-      "input": "Write a function that matches a word containing 'z'.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function that matches a word containing 'z'.\nYour code should pass this test case: assert text_match_wordz(\"pythonz.\")==('Found a match!')",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"pythonz.\")==('Found a match!')\n    assert candidate(\"xyz.\")==('Found a match!')\n    assert candidate(\"  lang  .\")==('Not matched!')\n",
       "language": "python"
     },
     {
       "id": 973,
-      "input": "Write a python function to left rotate the string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to left rotate the string.\nYour code should pass this test case: assert left_rotate(\"python\",2) == \"thonpy\"   ",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"python\",2) == \"thonpy\"   \n    assert candidate(\"bigdata\",3 ) == \"databig\" \n    assert candidate(\"hadoop\",1 ) == \"adooph\" \n",
       "language": "python"
     },
     {
       "id": 968,
-      "input": "Write a python function to find maximum possible value for the given periodic function.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find maximum possible value for the given periodic function.\nYour code should pass this test case: assert floor_Max(11,10,9) == 9",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(11,10,9) == 9\n    assert candidate(5,7,4) == 2\n    assert candidate(2,2,1) == 1\n",
       "language": "python"
     },
     {
       "id": 116,
-      "input": "Write a function to convert a given tuple of positive integers into an integer.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to convert a given tuple of positive integers into an integer.\nYour code should pass this test case: assert tuple_to_int((1,2,3))==123",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((1,2,3))==123\n    assert candidate((4,5,6))==456\n    assert candidate((5,6,7))==567\n",
       "language": "python"
     },
     {
       "id": 712,
-      "input": "Write a function to remove duplicates from a list of lists.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to remove duplicates from a list of lists.\nYour code should pass this test case: assert remove_duplicate([[10, 20], [40], [30, 56, 25], [10, 20], [33], [40]])==[[10, 20], [30, 56, 25], [33], [40]] ",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[10, 20], [40], [30, 56, 25], [10, 20], [33], [40]])==[[10, 20], [30, 56, 25], [33], [40]] \n    assert candidate([\"a\", \"b\", \"a\", \"c\", \"c\"] )==[\"a\", \"b\", \"c\"]\n    assert candidate([1, 3, 5, 6, 3, 5, 6, 1] )==[1, 3, 5, 6]\n",
       "language": "python"
     },
     {
       "id": 353,
-      "input": "Write a function to remove a specified column from a given nested list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to remove a specified column from a given nested list.\nYour code should pass this test case: assert remove_column([[1, 2, 3], [2, 4, 5], [1, 1, 1]],0)==[[2, 3], [4, 5], [1, 1]]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[1, 2, 3], [2, 4, 5], [1, 1, 1]],0)==[[2, 3], [4, 5], [1, 1]]\n    assert candidate([[1, 2, 3], [-2, 4, -5], [1, -1, 1]],2)==[[1, 2], [-2, 4], [1, -1]]\n    assert candidate([[1, 3], [5, 7], [1, 3], [13, 15, 17], [5, 7], [9, 11]],0)==[[3], [7], [3], [15, 17], [7], [11]]\n",
       "language": "python"
     },
     {
       "id": 770,
-      "input": "Write a python function to find the sum of fourth power of first n odd natural numbers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the sum of fourth power of first n odd natural numbers.\nYour code should pass this test case: assert odd_Num_Sum(2) == 82",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(2) == 82\n    assert candidate(3) == 707\n    assert candidate(4) == 3108\n",
       "language": "python"
     },
     {
       "id": 390,
-      "input": "Write a function to insert a given string at the beginning of all items in a list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to insert a given string at the beginning of all items in a list.\nYour code should pass this test case: assert add_string([1,2,3,4],'temp{0}')==['temp1', 'temp2', 'temp3', 'temp4']",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,3,4],'temp{0}')==['temp1', 'temp2', 'temp3', 'temp4']\n    assert candidate(['a','b','c','d'], 'python{0}')==[ 'pythona', 'pythonb', 'pythonc', 'pythond']\n    assert candidate([5,6,7,8],'string{0}')==['string5', 'string6', 'string7', 'string8']\n",
       "language": "python"
     },
     {
       "id": 860,
-      "input": "Write a function to check whether the given string is ending with only alphanumeric characters or not using regex.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check whether the given string is ending with only alphanumeric characters or not using regex.\nYour code should pass this test case: assert check_alphanumeric(\"dawood@\") == 'Discard'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"dawood@\") == 'Discard'\n    assert candidate(\"skdmsam326\") == 'Accept'\n    assert candidate(\"cooltricks@\") == 'Discard'\n",
       "language": "python"
     },
     {
       "id": 856,
-      "input": "Write a python function to find minimum adjacent swaps required to sort binary array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find minimum adjacent swaps required to sort binary array.\nYour code should pass this test case: assert find_Min_Swaps([1,0,1,0],4) == 3",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,0,1,0],4) == 3\n    assert candidate([0,1,0],3) == 1\n    assert candidate([0,0,1,1,0],5) == 2\n",
       "language": "python"
     },
     {
       "id": 494,
-      "input": "Write a function to convert the given binary tuple to integer.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to convert the given binary tuple to integer.\nYour code should pass this test case: assert binary_to_integer((1, 1, 0, 1, 0, 0, 1)) == '105'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((1, 1, 0, 1, 0, 0, 1)) == '105'\n    assert candidate((0, 1, 1, 0, 0, 1, 0, 1)) == '101'\n    assert candidate((1, 1, 0, 1, 0, 1)) == '53'\n",
       "language": "python"
     },
     {
       "id": 905,
-      "input": "Write a python function to find the sum of squares of binomial co-efficients.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the sum of squares of binomial co-efficients.\nYour code should pass this test case: assert sum_of_square(4) == 70",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(4) == 70\n    assert candidate(5) == 252\n    assert candidate(2) == 6\n",
       "language": "python"
     },
     {
       "id": 324,
-      "input": "Write a function to extract the sum of alternate chains of tuples.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to extract the sum of alternate chains of tuples.\nYour code should pass this test case: assert sum_of_alternates((5, 6, 3, 6, 10, 34)) == (46, 18)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((5, 6, 3, 6, 10, 34)) == (46, 18)\n    assert candidate((1, 2, 3, 4, 5)) == (6, 9)\n    assert candidate((6, 7, 8, 9, 4, 5)) == (21, 18)\n",
       "language": "python"
     },
     {
       "id": 951,
-      "input": "Write a function to find the maximum of similar indices in two lists of tuples.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the maximum of similar indices in two lists of tuples.\nYour code should pass this test case: assert max_similar_indices([(2, 4), (6, 7), (5, 1)],[(5, 4), (8, 10), (8, 14)]) == [(5, 4), (8, 10), (8, 14)]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([(2, 4), (6, 7), (5, 1)],[(5, 4), (8, 10), (8, 14)]) == [(5, 4), (8, 10), (8, 14)]\n    assert candidate([(3, 5), (7, 8), (6, 2)],[(6, 5), (9, 11), (9, 15)]) == [(6, 5), (9, 11), (9, 15)]\n    assert candidate([(4, 6), (8, 9), (7, 3)],[(7, 6), (10, 12), (10, 16)]) == [(7, 6), (10, 12), (10, 16)]\n",
       "language": "python"
     },
     {
       "id": 543,
-      "input": "Write a function to add two numbers and print number of digits of sum.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to add two numbers and print number of digits of sum.\nYour code should pass this test case: assert count_digits(9875,10)==(4)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(9875,10)==(4)\n    assert candidate(98759853034,100)==(11)\n    assert candidate(1234567,500)==(7)\n",
       "language": "python"
     },
     {
       "id": 758,
-      "input": "Write a function to count number of unique lists within a list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to count number of unique lists within a list.\nYour code should pass this test case: assert unique_sublists([[1, 3], [5, 7], [1, 3], [13, 15, 17], [5, 7], [9, 11]] )=={(1, 3): 2, (5, 7): 2, (13, 15, 17): 1, (9, 11): 1}",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[1, 3], [5, 7], [1, 3], [13, 15, 17], [5, 7], [9, 11]] )=={(1, 3): 2, (5, 7): 2, (13, 15, 17): 1, (9, 11): 1}\n    assert candidate([['green', 'orange'], ['black'], ['green', 'orange'], ['white']])=={('green', 'orange'): 2, ('black',): 1, ('white',): 1}\n    assert candidate([[10, 20, 30, 40], [60, 70, 50, 50], [90, 100, 200]])=={(10, 20, 30, 40): 1, (60, 70, 50, 50): 1, (90, 100, 200): 1}\n",
       "language": "python"
     },
     {
       "id": 52,
-      "input": "Write a function to caluclate area of a parallelogram.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to caluclate area of a parallelogram.\nYour code should pass this test case: assert parallelogram_area(10,20)==200",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10,20)==200\n    assert candidate(15,20)==300\n    assert candidate(8,9)==72\n",
       "language": "python"
     },
     {
       "id": 460,
-      "input": "Write a python function to get the first element of each sublist.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to get the first element of each sublist.\nYour code should pass this test case: assert Extract([[1, 2], [3, 4, 5], [6, 7, 8, 9]]) == [1, 3, 6]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[1, 2], [3, 4, 5], [6, 7, 8, 9]]) == [1, 3, 6]\n    assert candidate([[1,2,3],[4, 5]]) == [1,4]\n    assert candidate([[9,8,1],[1,2]]) == [9,1]\n",
       "language": "python"
     },
     {
       "id": 674,
-      "input": "Write a function to remove duplicate words from a given string using collections module.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to remove duplicate words from a given string using collections module.\nYour code should pass this test case: assert remove_duplicate(\"Python Exercises Practice Solution Exercises\")==(\"Python Exercises Practice Solution\")",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"Python Exercises Practice Solution Exercises\")==(\"Python Exercises Practice Solution\")\n    assert candidate(\"Python Exercises Practice Solution Python\")==(\"Python Exercises Practice Solution\")\n    assert candidate(\"Python Exercises Practice Solution Practice\")==(\"Python Exercises Practice Solution\")\n",
       "language": "python"
     },
     {
       "id": 338,
-      "input": "Write a python function to count the number of substrings with same first and last characters.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count the number of substrings with same first and last characters.\nYour code should pass this test case: assert count_Substring_With_Equal_Ends('aba') == 4",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('aba') == 4\n    assert candidate('abcab') == 7\n    assert candidate('abc') == 3\n",
       "language": "python"
     },
     {
       "id": 698,
-      "input": "Write a function to sort dictionary items by tuple product of keys for the given dictionary with tuple keys.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to sort dictionary items by tuple product of keys for the given dictionary with tuple keys.\nYour code should pass this test case: assert sort_dict_item({(5, 6) : 3, (2, 3) : 9, (8, 4): 10, (6, 4): 12} ) == {(2, 3): 9, (6, 4): 12, (5, 6): 3, (8, 4): 10}",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate({(5, 6) : 3, (2, 3) : 9, (8, 4): 10, (6, 4): 12} ) == {(2, 3): 9, (6, 4): 12, (5, 6): 3, (8, 4): 10}\n    assert candidate({(6, 7) : 4, (3, 4) : 10, (9, 5): 11, (7, 5): 13} ) == {(3, 4): 10, (7, 5): 13, (6, 7): 4, (9, 5): 11}\n    assert candidate({(7, 8) : 5, (4, 5) : 11, (10, 6): 12, (8, 6): 14} ) == {(4, 5): 11, (8, 6): 14, (7, 8): 5, (10, 6): 12}\n",
       "language": "python"
     },
     {
       "id": 949,
-      "input": "Write a function to sort the given tuple list basis the total digits in tuple.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to sort the given tuple list basis the total digits in tuple.\nYour code should pass this test case: assert sort_list([(3, 4, 6, 723), (1, 2), (12345,), (134, 234, 34)] ) == '[(1, 2), (12345,), (3, 4, 6, 723), (134, 234, 34)]'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([(3, 4, 6, 723), (1, 2), (12345,), (134, 234, 34)] ) == '[(1, 2), (12345,), (3, 4, 6, 723), (134, 234, 34)]'\n    assert candidate([(3, 4, 8), (1, 2), (1234335,), (1345, 234, 334)] ) == '[(1, 2), (3, 4, 8), (1234335,), (1345, 234, 334)]'\n    assert candidate([(34, 4, 61, 723), (1, 2), (145,), (134, 23)] ) == '[(1, 2), (145,), (134, 23), (34, 4, 61, 723)]'\n",
       "language": "python"
     },
     {
       "id": 202,
-      "input": "Write a function to remove even characters in a string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to remove even characters in a string.\nYour code should pass this test case: assert remove_even(\"python\")==(\"pto\")",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"python\")==(\"pto\")\n    assert candidate(\"program\")==(\"porm\")\n    assert candidate(\"language\")==(\"lnug\")\n",
       "language": "python"
     },
     {
       "id": 54,
-      "input": "Write a function to sort the given array by using counting sort.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to sort the given array by using counting sort.\nYour code should pass this test case: assert counting_sort([1,23,4,5,6,7,8]) == [1, 4, 5, 6, 7, 8, 23]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,23,4,5,6,7,8]) == [1, 4, 5, 6, 7, 8, 23]\n    assert candidate([12, 9, 28, 33, 69, 45]) == [9, 12, 28, 33, 45, 69]\n    assert candidate([8, 4, 14, 3, 2, 1]) == [1, 2, 3, 4, 8, 14]\n",
       "language": "python"
     },
     {
       "id": 154,
-      "input": "Write a function to extract every specified element from a given two dimensional list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to extract every specified element from a given two dimensional list.\nYour code should pass this test case: assert specified_element([[1, 2, 3, 2], [4, 5, 6, 2], [7, 1, 9, 5]],0)==[1, 4, 7]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[1, 2, 3, 2], [4, 5, 6, 2], [7, 1, 9, 5]],0)==[1, 4, 7]\n    assert candidate([[1, 2, 3, 2], [4, 5, 6, 2], [7, 1, 9, 5]],2)==[3, 6, 9]\n    assert candidate([[1, 2, 3, 2], [4, 5, 6, 2], [7, 1, 9, 5]],3)==[2,2,5]\n",
       "language": "python"
     },
     {
       "id": 875,
-      "input": "Write a function to find the minimum difference in the tuple pairs of given tuples.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the minimum difference in the tuple pairs of given tuples.\nYour code should pass this test case: assert min_difference([(3, 5), (1, 7), (10, 3), (1, 2)]) == 1",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([(3, 5), (1, 7), (10, 3), (1, 2)]) == 1\n    assert candidate([(4, 6), (12, 8), (11, 4), (2, 13)]) == 2\n    assert candidate([(5, 17), (3, 9), (12, 5), (3, 24)]) == 6\n",
       "language": "python"
     },
     {
       "id": 339,
-      "input": "Write a python function to find the maximum occuring divisor in an interval.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the maximum occuring divisor in an interval.\nYour code should pass this test case: assert find_Divisor(2,2) == 2",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(2,2) == 2\n    assert candidate(2,5) == 2\n    assert candidate(5,10) == 2\n",
       "language": "python"
     },
     {
       "id": 278,
-      "input": "Write a function to find the element count that occurs before the record in the given tuple.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the element count that occurs before the record in the given tuple.\nYour code should pass this test case: assert count_first_elements((1, 5, 7, (4, 6), 10) ) == 3",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((1, 5, 7, (4, 6), 10) ) == 3\n    assert candidate((2, 9, (5, 7), 11) ) == 2\n    assert candidate((11, 15, 5, 8, (2, 3), 8) ) == 4\n",
       "language": "python"
     },
     {
       "id": 425,
-      "input": "Write a function to count the number of sublists containing a particular element.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to count the number of sublists containing a particular element.\nYour code should pass this test case: assert count_element_in_list([[1, 3], [5, 7], [1, 11], [1, 15, 7]],1)==3",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[1, 3], [5, 7], [1, 11], [1, 15, 7]],1)==3\n    assert candidate([['A', 'B'], ['A', 'C'], ['A', 'D', 'E'], ['B', 'C', 'D']],'A')==3\n    assert candidate([['A', 'B'], ['A', 'C'], ['A', 'D', 'E'], ['B', 'C', 'D']],'E')==1\n",
       "language": "python"
     },
     {
       "id": 276,
-      "input": "Write a function to find the volume of a cylinder.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the volume of a cylinder.\nYour code should pass this test case: assert volume_cylinder(10,5)==1570.7500000000002",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10,5)==1570.7500000000002\n    assert candidate(4,5)==251.32000000000002\n    assert candidate(4,10)==502.64000000000004\n",
       "language": "python"
     },
     {
       "id": 741,
-      "input": "Write a python function to check whether all the characters are same or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether all the characters are same or not.\nYour code should pass this test case: assert all_Characters_Same(\"python\") == False",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"python\") == False\n    assert candidate(\"aaa\") == True\n    assert candidate(\"data\") == False\n",
       "language": "python"
     },
     {
       "id": 760,
-      "input": "Write a python function to check whether an array contains only one distinct element or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether an array contains only one distinct element or not.\nYour code should pass this test case: assert unique_Element([1,1,1],3) == 'YES'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,1,1],3) == 'YES'\n    assert candidate([1,2,1,2],4) == 'NO'\n    assert candidate([1,2,3,4,5],5) == 'NO'\n",
       "language": "python"
     },
     {
       "id": 710,
-      "input": "Write a function to access the initial and last data of the given tuple record.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to access the initial and last data of the given tuple record.\nYour code should pass this test case: assert front_and_rear((10, 4, 5, 6, 7)) == (10, 7)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((10, 4, 5, 6, 7)) == (10, 7)\n    assert candidate((1, 2, 3, 4, 5)) == (1, 5)\n    assert candidate((6, 7, 8, 9, 10)) == (6, 10)\n",
       "language": "python"
     },
     {
       "id": 140,
-      "input": "Write a function to extract elements that occur singly in the given tuple list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to extract elements that occur singly in the given tuple list.\nYour code should pass this test case: assert extract_singly([(3, 4, 5), (4, 5, 7), (1, 4)]) == [3, 4, 5, 7, 1]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([(3, 4, 5), (4, 5, 7), (1, 4)]) == [3, 4, 5, 7, 1]\n    assert candidate([(1, 2, 3), (4, 2, 3), (7, 8)]) == [1, 2, 3, 4, 7, 8]\n    assert candidate([(7, 8, 9), (10, 11, 12), (10, 11)]) == [7, 8, 9, 10, 11, 12]\n",
       "language": "python"
     },
     {
       "id": 402,
-      "input": "Write a function to compute the value of ncr%p.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to compute the value of ncr%p.\nYour code should pass this test case: assert ncr_modp(10,2,13)==6",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10,2,13)==6\n    assert candidate(15,12,43)==25\n    assert candidate(17,9,18)==10\n",
       "language": "python"
     },
     {
       "id": 195,
-      "input": "Write a python function to find the first position of an element in a sorted array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the first position of an element in a sorted array.\nYour code should pass this test case: assert first([1,2,3,4,5,6,6],6,6) == 5",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,3,4,5,6,6],6,6) == 5\n    assert candidate([1,2,2,2,3,2,2,4,2],2,9) == 1\n    assert candidate([1,2,3],1,3) == 0\n",
       "language": "python"
     },
     {
       "id": 845,
-      "input": "Write a python function to count the number of digits in factorial of a given number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count the number of digits in factorial of a given number.\nYour code should pass this test case: assert find_Digits(7) == 4",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(7) == 4\n    assert candidate(5) == 3\n    assert candidate(4) == 2\n",
       "language": "python"
     },
     {
       "id": 607,
-      "input": "Write a function to search a literals string in a string and also find the location within the original string where the pattern occurs by using regex.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to search a literals string in a string and also find the location within the original string where the pattern occurs by using regex.\nYour code should pass this test case: assert find_literals('The quick brown fox jumps over the lazy dog.', 'fox') == ('fox', 16, 19)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('The quick brown fox jumps over the lazy dog.', 'fox') == ('fox', 16, 19)\n    assert candidate('Its been a very crazy procedure right', 'crazy') == ('crazy', 16, 21)\n    assert candidate('Hardest choices required strongest will', 'will') == ('will', 35, 39)\n",
       "language": "python"
     },
     {
       "id": 394,
-      "input": "Write a function to check if given tuple is distinct or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check if given tuple is distinct or not.\nYour code should pass this test case: assert check_distinct((1, 4, 5, 6, 1, 4)) == False",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((1, 4, 5, 6, 1, 4)) == False\n    assert candidate((1, 4, 5, 6)) == True\n    assert candidate((2, 3, 4, 5, 6)) == True\n",
       "language": "python"
     },
     {
       "id": 892,
-      "input": "Write a function to remove multiple spaces in a string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to remove multiple spaces in a string.\nYour code should pass this test case: assert remove_spaces('python  program')==('python program')",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('python  program')==('python program')\n    assert candidate('python   programming    language')==('python programming language')\n    assert candidate('python                     program')==('python program')\n",
       "language": "python"
     },
     {
       "id": 945,
-      "input": "Write a function to convert the given tuples into set.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to convert the given tuples into set.\nYour code should pass this test case: assert tuple_to_set(('x', 'y', 'z') ) == {'y', 'x', 'z'}",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(('x', 'y', 'z') ) == {'y', 'x', 'z'}\n    assert candidate(('a', 'b', 'c') ) == {'c', 'a', 'b'}\n    assert candidate(('z', 'd', 'e') ) == {'d', 'e', 'z'}\n",
       "language": "python"
     },
     {
       "id": 48,
-      "input": "Write a python function to set all odd bits of a given number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to set all odd bits of a given number.\nYour code should pass this test case: assert odd_bit_set_number(10) == 15",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10) == 15\n    assert candidate(20) == 21\n    assert candidate(30) == 31\n",
       "language": "python"
     },
     {
       "id": 398,
-      "input": "Write a function to compute the sum of digits of each number of a given list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to compute the sum of digits of each number of a given list.\nYour code should pass this test case: assert sum_of_digits([10,2,56])==14",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([10,2,56])==14\n    assert candidate([[10,20,4,5,'b',70,'a']])==19\n    assert candidate([10,20,-4,5,-70])==19\n",
       "language": "python"
     },
     {
       "id": 346,
-      "input": "Write a function to find entringer number e(n, k).",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find entringer number e(n, k).\nYour code should pass this test case: assert zigzag(4, 3) == 5",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(4, 3) == 5\n    assert candidate(4, 2) == 4\n    assert candidate(3, 1) == 1\n",
       "language": "python"
     },
     {
       "id": 265,
-      "input": "Write a function to split a list for every nth element.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to split a list for every nth element.\nYour code should pass this test case: assert list_split(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n'],3)==[['a', 'd', 'g', 'j', 'm'], ['b', 'e', 'h', 'k', 'n'], ['c', 'f', 'i', 'l']] ",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n'],3)==[['a', 'd', 'g', 'j', 'm'], ['b', 'e', 'h', 'k', 'n'], ['c', 'f', 'i', 'l']] \n    assert candidate([1,2,3,4,5,6,7,8,9,10,11,12,13,14],3)==[[1,4,7,10,13], [2,5,8,11,14], [3,6,9,12]] \n    assert candidate(['python','java','C','C++','DBMS','SQL'],2)==[['python', 'C', 'DBMS'], ['java', 'C++', 'SQL']] \n",
       "language": "python"
     },
     {
       "id": 72,
-      "input": "Write a python function to check whether the given number can be represented as difference of two squares or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether the given number can be represented as difference of two squares or not.\nYour code should pass this test case: assert dif_Square(5) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(5) == True\n    assert candidate(10) == False\n    assert candidate(15) == True\n",
       "language": "python"
     },
     {
       "id": 145,
-      "input": "Write a python function to find the maximum difference between any two elements in a given array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the maximum difference between any two elements in a given array.\nYour code should pass this test case: assert max_Abs_Diff((2,1,5,3),4) == 4",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((2,1,5,3),4) == 4\n    assert candidate((9,3,2,5,1),5) == 8\n    assert candidate((3,2,1),3) == 2\n",
       "language": "python"
     },
     {
       "id": 380,
-      "input": "Write a function to generate a two-dimensional array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to generate a two-dimensional array.\nYour code should pass this test case: assert multi_list(3,4)==[[0, 0, 0, 0], [0, 1, 2, 3], [0, 2, 4, 6]] ",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(3,4)==[[0, 0, 0, 0], [0, 1, 2, 3], [0, 2, 4, 6]] \n    assert candidate(5,7)==[[0, 0, 0, 0, 0, 0, 0], [0, 1, 2, 3, 4, 5, 6], [0, 2, 4, 6, 8, 10, 12], [0, 3, 6, 9, 12, 15, 18], [0, 4, 8, 12, 16, 20, 24]]\n    assert candidate(10,15)==[[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28], [0, 3, 6, 9, 12, 15, 18, 21, 24, 27, 30, 33, 36, 39, 42], [0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56], [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70], [0, 6, 12, 18, 24, 30, 36, 42, 48, 54, 60, 66, 72, 78, 84], [0, 7, 14, 21, 28, 35, 42, 49, 56, 63, 70, 77, 84, 91, 98], [0, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112], [0, 9, 18, 27, 36, 45, 54, 63, 72, 81, 90, 99, 108, 117, 126]]\n",
       "language": "python"
     },
     {
       "id": 525,
-      "input": "Write a python function to check whether two given lines are parallel or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether two given lines are parallel or not.\nYour code should pass this test case: assert parallel_lines([2,3,4], [2,3,8]) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([2,3,4], [2,3,8]) == True\n    assert candidate([2,3,4], [4,-3,8]) == False\n    assert candidate([3,3],[5,5]) == True\n",
       "language": "python"
     },
     {
       "id": 616,
-      "input": "Write a function to perfom the modulo of tuple elements in the given two tuples.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to perfom the modulo of tuple elements in the given two tuples.\nYour code should pass this test case: assert tuple_modulo((10, 4, 5, 6), (5, 6, 7, 5)) == (0, 4, 5, 1)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((10, 4, 5, 6), (5, 6, 7, 5)) == (0, 4, 5, 1)\n    assert candidate((11, 5, 6, 7), (6, 7, 8, 6)) == (5, 5, 6, 1)\n    assert candidate((12, 6, 7, 8), (7, 8, 9, 7)) == (5, 6, 7, 1)\n",
       "language": "python"
     },
     {
       "id": 702,
-      "input": "Write a function to find the minimum number of elements that should be removed such that amax-amin<=k.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the minimum number of elements that should be removed such that amax-amin<=k.\nYour code should pass this test case: assert removals([1, 3, 4, 9, 10,11, 12, 17, 20], 9, 4) == 5",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 3, 4, 9, 10,11, 12, 17, 20], 9, 4) == 5\n    assert candidate([1, 5, 6, 2, 8], 5, 2) == 3\n    assert candidate([1, 2, 3 ,4, 5, 6], 6, 3) == 2\n",
       "language": "python"
     },
     {
       "id": 392,
-      "input": "Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the maximum sum possible by using the given equation f(n) = max( (f(n/2) + f(n/3) + f(n/4) + f(n/5)), n).\nYour code should pass this test case: assert get_max_sum(60) == 106",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(60) == 106\n    assert candidate(10) == 12\n    assert candidate(2) == 2\n",
       "language": "python"
     },
     {
       "id": 113,
-      "input": "Write a function to check if a string represents an integer or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check if a string represents an integer or not.\nYour code should pass this test case: assert check_integer(\"python\")==False",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"python\")==False\n    assert candidate(\"1\")==True\n    assert candidate(\"12345\")==True\n",
       "language": "python"
     },
     {
       "id": 642,
-      "input": "Write a function to remove similar rows from the given tuple matrix.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to remove similar rows from the given tuple matrix.\nYour code should pass this test case: assert remove_similar_row([[(4, 5), (3, 2)], [(2, 2), (4, 6)], [(3, 2), (4, 5)]] ) == {((2, 2), (4, 6)), ((3, 2), (4, 5))}",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[(4, 5), (3, 2)], [(2, 2), (4, 6)], [(3, 2), (4, 5)]] ) == {((2, 2), (4, 6)), ((3, 2), (4, 5))}\n    assert candidate([[(5, 6), (4, 3)], [(3, 3), (5, 7)], [(4, 3), (5, 6)]] ) == {((4, 3), (5, 6)), ((3, 3), (5, 7))}\n    assert candidate([[(6, 7), (5, 4)], [(4, 4), (6, 8)], [(5, 4), (6, 7)]] ) =={((4, 4), (6, 8)), ((5, 4), (6, 7))}\n",
       "language": "python"
     },
     {
       "id": 566,
-      "input": "Write a function to get the sum of a non-negative integer.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to get the sum of a non-negative integer.\nYour code should pass this test case: assert sum_digits(345)==12",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(345)==12\n    assert candidate(12)==3\n    assert candidate(97)==16\n",
       "language": "python"
     },
     {
       "id": 894,
-      "input": "Write a function to convert the given string of float type into tuple.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to convert the given string of float type into tuple.\nYour code should pass this test case: assert float_to_tuple(\"1.2, 1.3, 2.3, 2.4, 6.5\") == (1.2, 1.3, 2.3, 2.4, 6.5)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"1.2, 1.3, 2.3, 2.4, 6.5\") == (1.2, 1.3, 2.3, 2.4, 6.5)\n    assert candidate(\"2.3, 2.4, 5.6, 5.4, 8.9\") == (2.3, 2.4, 5.6, 5.4, 8.9)\n    assert candidate(\"0.3, 0.5, 7.8, 9.4\") == (0.3, 0.5, 7.8, 9.4)\n",
       "language": "python"
     },
     {
       "id": 403,
-      "input": "Write a function to check if a url is valid or not using regex.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check if a url is valid or not using regex.\nYour code should pass this test case: assert is_valid_URL(\"https://www.google.com\") == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"https://www.google.com\") == True\n    assert candidate(\"https:/www.gmail.com\") == False\n    assert candidate(\"https:// www.redit.com\") == False\n",
       "language": "python"
     },
     {
       "id": 33,
-      "input": "Write a python function to convert a decimal number to binary number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to convert a decimal number to binary number.\nYour code should pass this test case: assert decimal_To_Binary(10) == 1010",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10) == 1010\n    assert candidate(1) == 1\n    assert candidate(20) == 10100\n",
       "language": "python"
     },
     {
       "id": 211,
-      "input": "Write a python function to count numbers whose oth and nth bits are set.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count numbers whose oth and nth bits are set.\nYour code should pass this test case: assert count_Num(2) == 1",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(2) == 1\n    assert candidate(3) == 2\n    assert candidate(1) == 1\n",
       "language": "python"
     },
     {
       "id": 355,
-      "input": "Write a python function to count the number of rectangles in a circle of radius r.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count the number of rectangles in a circle of radius r.\nYour code should pass this test case: assert count_Rectangles(2) == 8",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(2) == 8\n    assert candidate(1) == 1\n    assert candidate(0) == 0\n",
       "language": "python"
     },
     {
       "id": 108,
-      "input": "Write a function to merge multiple sorted inputs into a single sorted iterator using heap queue algorithm.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to merge multiple sorted inputs into a single sorted iterator using heap queue algorithm.\nYour code should pass this test case: assert merge_sorted_list([25, 24, 15, 4, 5, 29, 110],[19, 20, 11, 56, 25, 233, 154],[24, 26, 54, 48])==[4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([25, 24, 15, 4, 5, 29, 110],[19, 20, 11, 56, 25, 233, 154],[24, 26, 54, 48])==[4, 5, 11, 15, 19, 20, 24, 24, 25, 25, 26, 29, 48, 54, 56, 110, 154, 233]\n    assert candidate([1, 3, 5, 6, 8, 9], [2, 5, 7, 11], [1, 4, 7, 8, 12])==[1, 1, 2, 3, 4, 5, 5, 6, 7, 7, 8, 8, 9, 11, 12]\n    assert candidate([18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1],[25, 35, 22, 85, 14, 65, 75, 25, 58],[12, 74, 9, 50, 61, 41])==[1, 2, 3, 4, 7, 8, 9, 9, 9, 10, 12, 14, 14, 18, 22, 25, 25, 35, 41, 50, 58, 61, 65, 74, 75, 85]\n",
       "language": "python"
     },
     {
       "id": 472,
-      "input": "Write a python function to check whether the given list contains consecutive numbers or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether the given list contains consecutive numbers or not.\nYour code should pass this test case: assert check_Consecutive([1,2,3,4,5]) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,3,4,5]) == True\n    assert candidate([1,2,3,5,6]) == False\n    assert candidate([1,2,1]) == False\n",
       "language": "python"
     },
     {
       "id": 568,
-      "input": "Write a function to create a list of empty dictionaries.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to create a list of empty dictionaries.\nYour code should pass this test case: assert empty_list(5)==[{},{},{},{},{}]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(5)==[{},{},{},{},{}]\n    assert candidate(6)==[{},{},{},{},{},{}]\n    assert candidate(7)==[{},{},{},{},{},{},{}]\n",
       "language": "python"
     },
     {
       "id": 883,
-      "input": "Write a function to find numbers divisible by m and n from a list of numbers using lambda function.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find numbers divisible by m and n from a list of numbers using lambda function.\nYour code should pass this test case: assert div_of_nums([19, 65, 57, 39, 152, 639, 121, 44, 90, 190],2,4)==[ 152,44]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([19, 65, 57, 39, 152, 639, 121, 44, 90, 190],2,4)==[ 152,44]\n    assert candidate([1, 2, 3, 5, 7, 8, 10],2,5)==[10]\n    assert candidate([10,15,14,13,18,12,20],10,5)==[10,20]\n",
       "language": "python"
     },
     {
       "id": 571,
-      "input": "Write a function to find maximum possible sum of disjoint pairs for the given array of integers and a number k.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find maximum possible sum of disjoint pairs for the given array of integers and a number k.\nYour code should pass this test case: assert max_sum_pair_diff_lessthan_K([3, 5, 10, 15, 17, 12, 9], 7, 4) == 62",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([3, 5, 10, 15, 17, 12, 9], 7, 4) == 62\n    assert candidate([5, 15, 10, 300], 4, 12) == 25\n    assert candidate([1, 2, 3, 4, 5, 6], 6, 6) == 21\n",
       "language": "python"
     },
     {
       "id": 938,
-      "input": "Write a function to find three closest elements from three sorted arrays.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find three closest elements from three sorted arrays.\nYour code should pass this test case: assert find_closet([1, 4, 10],[2, 15, 20],[10, 12],3,3,2) == (10, 15, 10)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 4, 10],[2, 15, 20],[10, 12],3,3,2) == (10, 15, 10)\n    assert candidate([20, 24, 100],[2, 19, 22, 79, 800],[10, 12, 23, 24, 119],3,5,5) == (24, 22, 23)\n    assert candidate([2, 5, 11],[3, 16, 21],[11, 13],3,3,2) == (11, 16, 11)\n",
       "language": "python"
     },
     {
       "id": 891,
-      "input": "Write a python function to check whether the given two numbers have same number of digits or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether the given two numbers have same number of digits or not.\nYour code should pass this test case: assert same_Length(12,1) == False",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(12,1) == False\n    assert candidate(2,2) == True\n    assert candidate(10,20) == True\n",
       "language": "python"
     },
     {
       "id": 345,
-      "input": "Write a function to find the difference between two consecutive numbers in a given list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the difference between two consecutive numbers in a given list.\nYour code should pass this test case: assert diff_consecutivenums([1, 1, 3, 4, 4, 5, 6, 7])==[0, 2, 1, 0, 1, 1, 1]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 1, 3, 4, 4, 5, 6, 7])==[0, 2, 1, 0, 1, 1, 1]\n    assert candidate([4, 5, 8, 9, 6, 10])==[1, 3, 1, -3, 4]\n    assert candidate([0, 1, 2, 3, 4, 4, 4, 4, 5, 7])==[1, 1, 1, 1, 0, 0, 0, 1, 2]\n",
       "language": "python"
     },
     {
       "id": 178,
-      "input": "Write a function to search some literals strings in a string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to search some literals strings in a string.\nYour code should pass this test case: assert string_literals(['language'],'python language')==('Matched!')",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(['language'],'python language')==('Matched!')\n    assert candidate(['program'],'python language')==('Not Matched!')\n    assert candidate(['python'],'programming language')==('Not Matched!')\n",
       "language": "python"
     },
     {
       "id": 686,
-      "input": "Write a function to find the frequency of each element in the given list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the frequency of each element in the given list.\nYour code should pass this test case: assert freq_element((4, 5, 4, 5, 6, 6, 5, 5, 4) ) == '{4: 3, 5: 4, 6: 2}'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((4, 5, 4, 5, 6, 6, 5, 5, 4) ) == '{4: 3, 5: 4, 6: 2}'\n    assert candidate((7, 8, 8, 9, 4, 7, 6, 5, 4) ) == '{7: 2, 8: 2, 9: 1, 4: 2, 6: 1, 5: 1}'\n    assert candidate((1, 4, 3, 1, 4, 5, 2, 6, 2, 7) ) == '{1: 2, 4: 2, 3: 1, 5: 1, 2: 2, 6: 1, 7: 1}'\n",
       "language": "python"
     },
     {
       "id": 157,
-      "input": "Write a function to reflect the run-length encoding from a list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to reflect the run-length encoding from a list.\nYour code should pass this test case: assert encode_list([1,1,2,3,4,4.3,5,1])==[[2, 1], [1, 2], [1, 3], [1, 4], [1, 4.3], [1, 5], [1, 1]]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,1,2,3,4,4.3,5,1])==[[2, 1], [1, 2], [1, 3], [1, 4], [1, 4.3], [1, 5], [1, 1]]\n    assert candidate('automatically')==[[1, 'a'], [1, 'u'], [1, 't'], [1, 'o'], [1, 'm'], [1, 'a'], [1, 't'], [1, 'i'], [1, 'c'], [1, 'a'], [2, 'l'], [1, 'y']]\n    assert candidate('python')==[[1, 'p'], [1, 'y'], [1, 't'], [1, 'h'], [1, 'o'], [1, 'n']]\n",
       "language": "python"
     },
     {
       "id": 420,
-      "input": "Write a python function to find the cube sum of first n even natural numbers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the cube sum of first n even natural numbers.\nYour code should pass this test case: assert cube_Sum(2) == 72",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(2) == 72\n    assert candidate(3) == 288\n    assert candidate(4) == 800\n",
       "language": "python"
     },
     {
       "id": 902,
-      "input": "Write a function to combine two dictionaries by adding values for common keys.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to combine two dictionaries by adding values for common keys.\nYour code should pass this test case: assert add_dict({'a': 100, 'b': 200, 'c':300},{'a': 300, 'b': 200, 'd':400})==({'b': 400, 'd': 400, 'a': 400, 'c': 300}) ",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate({'a': 100, 'b': 200, 'c':300},{'a': 300, 'b': 200, 'd':400})==({'b': 400, 'd': 400, 'a': 400, 'c': 300}) \n    assert candidate({'a': 500, 'b': 700, 'c':900},{'a': 500, 'b': 600, 'd':900})==({'b': 1300, 'd': 900, 'a': 1000, 'c': 900}) \n    assert candidate({'a':900,'b':900,'d':900},{'a':900,'b':900,'d':900})==({'b': 1800, 'd': 1800, 'a': 1800})\n",
       "language": "python"
     },
     {
       "id": 6,
-      "input": "Write a python function to check whether the two numbers differ at one bit position only or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether the two numbers differ at one bit position only or not.\nYour code should pass this test case: assert differ_At_One_Bit_Pos(13,9) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(13,9) == True\n    assert candidate(15,8) == False\n    assert candidate(2,4) == False\n",
       "language": "python"
     },
     {
       "id": 661,
-      "input": "Write a function to find the maximum sum that can be formed which has no three consecutive elements present.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the maximum sum that can be formed which has no three consecutive elements present.\nYour code should pass this test case: assert max_sum_of_three_consecutive([100, 1000, 100, 1000, 1], 5) == 2101",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([100, 1000, 100, 1000, 1], 5) == 2101\n    assert candidate([3000, 2000, 1000, 3, 10], 5) == 5013\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8], 8) == 27\n",
       "language": "python"
     },
     {
       "id": 32,
-      "input": "Write a python function to find the largest prime factor of a given number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the largest prime factor of a given number.\nYour code should pass this test case: assert max_Prime_Factors(15) == 5",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(15) == 5\n    assert candidate(6) == 3\n    assert candidate(2) == 2\n",
       "language": "python"
     },
     {
       "id": 636,
-      "input": "Write a python function to check if roots of a quadratic equation are reciprocal of each other or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check if roots of a quadratic equation are reciprocal of each other or not.\nYour code should pass this test case: assert Check_Solution(2,0,2) == \"Yes\"",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(2,0,2) == \"Yes\"\n    assert candidate(2,-5,2) == \"Yes\"\n    assert candidate(1,2,3) == \"No\"\n",
       "language": "python"
     },
     {
       "id": 920,
-      "input": "Write a function to remove all tuples with all none values in the given tuple list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to remove all tuples with all none values in the given tuple list.\nYour code should pass this test case: assert remove_tuple([(None, 2), (None, None), (3, 4), (12, 3), (None, )] ) == '[(None, 2), (3, 4), (12, 3)]'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([(None, 2), (None, None), (3, 4), (12, 3), (None, )] ) == '[(None, 2), (3, 4), (12, 3)]'\n    assert candidate([(None, None), (None, None), (3, 6), (17, 3), (None,1 )] ) == '[(3, 6), (17, 3), (None, 1)]'\n    assert candidate([(1, 2), (2, None), (3, None), (24, 3), (None, None )] ) == '[(1, 2), (2, None), (3, None), (24, 3)]'\n",
       "language": "python"
     },
     {
       "id": 4,
-      "input": "Write a function to find the largest integers from a given list of numbers using heap queue algorithm.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the largest integers from a given list of numbers using heap queue algorithm.\nYour code should pass this test case: assert heap_queue_largest( [25, 35, 22, 85, 14, 65, 75, 22, 58],3)==[85, 75, 65] ",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate( [25, 35, 22, 85, 14, 65, 75, 22, 58],3)==[85, 75, 65] \n    assert candidate( [25, 35, 22, 85, 14, 65, 75, 22, 58],2)==[85, 75] \n    assert candidate( [25, 35, 22, 85, 14, 65, 75, 22, 58],5)==[85, 75, 65, 58, 35]\n",
       "language": "python"
     },
     {
       "id": 755,
-      "input": "Write a function to find the second smallest number in a list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the second smallest number in a list.\nYour code should pass this test case: assert second_smallest([1, 2, -8, -2, 0, -2])==-2",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 2, -8, -2, 0, -2])==-2\n    assert candidate([1, 1, -0.5, 0, 2, -2, -2])==-0.5\n    assert candidate([2,2])==None\n",
       "language": "python"
     },
     {
       "id": 935,
-      "input": "Write a function to calculate the sum of series 1\u00b2+2\u00b2+3\u00b2+\u2026.+n\u00b2.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to calculate the sum of series 1\u00b2+2\u00b2+3\u00b2+\u2026.+n\u00b2.\nYour code should pass this test case: assert series_sum(6)==91",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(6)==91\n    assert candidate(7)==140\n    assert candidate(12)==650\n",
       "language": "python"
     },
     {
       "id": 310,
-      "input": "Write a function to convert a given string to a tuple.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to convert a given string to a tuple.\nYour code should pass this test case: assert string_to_tuple(\"python 3.0\")==('p', 'y', 't', 'h', 'o', 'n', '3', '.', '0')",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"python 3.0\")==('p', 'y', 't', 'h', 'o', 'n', '3', '.', '0')\n    assert candidate(\"item1\")==('i', 't', 'e', 'm', '1')\n    assert candidate(\"15.10\")==('1', '5', '.', '1', '0')\n",
       "language": "python"
     },
     {
       "id": 890,
-      "input": "Write a python function to find the index of an extra element present in one sorted array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the index of an extra element present in one sorted array.\nYour code should pass this test case: assert find_Extra([1,2,3,4],[1,2,3],3) == 3",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,3,4],[1,2,3],3) == 3\n    assert candidate([2,4,6,8,10],[2,4,6,8],4) == 4\n    assert candidate([1,3,5,7,9,11],[1,3,5,7,9],5) == 5\n",
       "language": "python"
     },
     {
       "id": 506,
-      "input": "Write a function to calculate the permutation coefficient of given p(n, k).",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to calculate the permutation coefficient of given p(n, k).\nYour code should pass this test case: assert permutation_coefficient(10, 2) == 90",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10, 2) == 90\n    assert candidate(10, 3) == 720\n    assert candidate(10, 1) == 10\n",
       "language": "python"
     },
     {
       "id": 777,
-      "input": "Write a python function to find the sum of non-repeated elements in a given array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the sum of non-repeated elements in a given array.\nYour code should pass this test case: assert find_Sum([1,2,3,1,1,4,5,6],8) == 21",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,3,1,1,4,5,6],8) == 21\n    assert candidate([1,10,9,4,2,10,10,45,4],9) == 71\n    assert candidate([12,10,9,45,2,10,10,45,10],9) == 78\n",
       "language": "python"
     },
     {
       "id": 831,
-      "input": "Write a python function to count equal element pairs from the given array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count equal element pairs from the given array.\nYour code should pass this test case: assert count_Pairs([1,1,1,1],4) == 6",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,1,1,1],4) == 6\n    assert candidate([1,5,1],3) == 1\n    assert candidate([3,2,1,7,8,9],6) == 0\n",
       "language": "python"
     },
     {
       "id": 941,
-      "input": "Write a function to count the elements in a list until an element is a tuple.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to count the elements in a list until an element is a tuple.\nYour code should pass this test case: assert count_elim([10,20,30,(10,20),40])==3",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([10,20,30,(10,20),40])==3\n    assert candidate([10,(20,30),(10,20),40])==1\n    assert candidate([(10,(20,30,(10,20),40))])==0\n",
       "language": "python"
     },
     {
       "id": 160,
-      "input": "Write a function to find x and y that satisfies ax + by = n.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find x and y that satisfies ax + by = n.\nYour code should pass this test case: assert solution(2, 3, 7) == ('x = ', 2, ', y = ', 1)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(2, 3, 7) == ('x = ', 2, ', y = ', 1)\n    assert candidate(4, 2, 7) == 'No solution'\n    assert candidate(1, 13, 17) == ('x = ', 4, ', y = ', 1)\n",
       "language": "python"
     },
     {
       "id": 197,
-      "input": "Write a function to perform the exponentiation of the given two tuples.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to perform the exponentiation of the given two tuples.\nYour code should pass this test case: assert find_exponentio((10, 4, 5, 6), (5, 6, 7, 5)) == (100000, 4096, 78125, 7776)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((10, 4, 5, 6), (5, 6, 7, 5)) == (100000, 4096, 78125, 7776)\n    assert candidate((11, 5, 6, 7), (6, 7, 8, 6)) == (1771561, 78125, 1679616, 117649)\n    assert candidate((12, 6, 7, 8), (7, 8, 9, 7)) == (35831808, 1679616, 40353607, 2097152)\n",
       "language": "python"
     },
     {
       "id": 298,
-      "input": "Write a function to find the nested list elements which are present in another list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the nested list elements which are present in another list.\nYour code should pass this test case: assert intersection_nested_lists( [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],[[12, 18, 23, 25, 45], [7, 11, 19, 24, 28], [1, 5, 8, 18, 15, 16]])==[[12], [7, 11], [1, 5, 8]]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate( [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],[[12, 18, 23, 25, 45], [7, 11, 19, 24, 28], [1, 5, 8, 18, 15, 16]])==[[12], [7, 11], [1, 5, 8]]\n    assert candidate([[2, 3, 1], [4, 5], [6, 8]], [[4, 5], [6, 8]])==[[], []]\n    assert candidate(['john','amal','joel','george'],[['john'],['jack','john','mary'],['howard','john'],['jude']])==[['john'], ['john'], ['john'], []]\n",
       "language": "python"
     },
     {
       "id": 735,
-      "input": "Write a python function to toggle bits of the number except the first and the last bit.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to toggle bits of the number except the first and the last bit.\nYour code should pass this test case: assert toggle_middle_bits(9) == 15",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(9) == 15\n    assert candidate(10) == 12\n    assert candidate(11) == 13\n",
       "language": "python"
     },
     {
       "id": 58,
-      "input": "Write a python function to check whether the given two integers have opposite sign or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether the given two integers have opposite sign or not.\nYour code should pass this test case: assert opposite_Signs(1,-2) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(1,-2) == True\n    assert candidate(3,2) == False\n    assert candidate(-10,-10) == False\n",
       "language": "python"
     },
     {
       "id": 532,
-      "input": "Write a function to check if the two given strings are permutations of each other.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check if the two given strings are permutations of each other.\nYour code should pass this test case: assert check_permutation(\"abc\", \"cba\") == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"abc\", \"cba\") == True\n    assert candidate(\"test\", \"ttew\") == False\n    assert candidate(\"xxyz\", \"yxzx\") == True\n",
       "language": "python"
     },
     {
       "id": 81,
-      "input": "Write a function to zip the two given tuples.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to zip the two given tuples.\nYour code should pass this test case: assert zip_tuples((7, 8, 4, 5, 9, 10),(1, 5, 6) ) == [(7, 1), (8, 5), (4, 6), (5, 1), (9, 5), (10, 6)]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((7, 8, 4, 5, 9, 10),(1, 5, 6) ) == [(7, 1), (8, 5), (4, 6), (5, 1), (9, 5), (10, 6)]\n    assert candidate((8, 9, 5, 6, 10, 11),(2, 6, 7) ) == [(8, 2), (9, 6), (5, 7), (6, 2), (10, 6), (11, 7)]\n    assert candidate((9, 10, 6, 7, 11, 12),(3, 7, 8) ) == [(9, 3), (10, 7), (6, 8), (7, 3), (11, 7), (12, 8)]\n",
       "language": "python"
     },
     {
       "id": 744,
-      "input": "Write a function to check if the given tuple has any none value or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check if the given tuple has any none value or not.\nYour code should pass this test case: assert check_none((10, 4, 5, 6, None)) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((10, 4, 5, 6, None)) == True\n    assert candidate((7, 8, 9, 11, 14)) == False\n    assert candidate((1, 2, 3, 4, None)) == True\n",
       "language": "python"
     },
     {
       "id": 952,
-      "input": "Write a function to compute the value of ncr mod p.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to compute the value of ncr mod p.\nYour code should pass this test case: assert nCr_mod_p(10, 2, 13) == 6",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10, 2, 13) == 6\n    assert candidate(11, 3, 14) == 11\n    assert candidate(18, 14, 19) == 1\n",
       "language": "python"
     },
     {
       "id": 782,
-      "input": "Write a python function to find the sum of all odd length subarrays.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the sum of all odd length subarrays.\nYour code should pass this test case: assert Odd_Length_Sum([1,2,4]) == 14",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,4]) == 14\n    assert candidate([1,2,1,2]) == 15\n    assert candidate([1,7]) == 8\n",
       "language": "python"
     },
     {
       "id": 320,
-      "input": "Write a function to calculate the difference between the squared sum of first n natural numbers and the sum of squared first n natural numbers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to calculate the difference between the squared sum of first n natural numbers and the sum of squared first n natural numbers.\nYour code should pass this test case: assert sum_difference(12)==5434",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(12)==5434\n    assert candidate(20)==41230\n    assert candidate(54)==2151270\n",
       "language": "python"
     },
     {
       "id": 934,
-      "input": "Write a function to find the nth delannoy number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the nth delannoy number.\nYour code should pass this test case: assert dealnnoy_num(3, 4) == 129",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(3, 4) == 129\n    assert candidate(3, 3) == 63\n    assert candidate(4, 5) == 681\n",
       "language": "python"
     },
     {
       "id": 249,
-      "input": "Write a function to find the intersection of two arrays using lambda function.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the intersection of two arrays using lambda function.\nYour code should pass this test case: assert intersection_array([1, 2, 3, 5, 7, 8, 9, 10],[1, 2, 4, 8, 9])==[1, 2, 8, 9]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 2, 3, 5, 7, 8, 9, 10],[1, 2, 4, 8, 9])==[1, 2, 8, 9]\n    assert candidate([1, 2, 3, 5, 7, 8, 9, 10],[3,5,7,9])==[3,5,7,9]\n    assert candidate([1, 2, 3, 5, 7, 8, 9, 10],[10,20,30,40])==[10]\n",
       "language": "python"
     },
     {
       "id": 109,
-      "input": "Write a python function to find the count of rotations of a binary string with odd value.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the count of rotations of a binary string with odd value.\nYour code should pass this test case: assert odd_Equivalent(\"011001\",6) == 3",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"011001\",6) == 3\n    assert candidate(\"11011\",5) == 4\n    assert candidate(\"1010\",4) == 2\n",
       "language": "python"
     },
     {
       "id": 56,
-      "input": "Write a python function to check if a given number is one less than twice its reverse.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check if a given number is one less than twice its reverse.\nYour code should pass this test case: assert check(70) == False",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(70) == False\n    assert candidate(23) == False\n    assert candidate(73) == True\n",
       "language": "python"
     },
     {
       "id": 871,
-      "input": "Write a python function to check whether the given strings are rotations of each other or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether the given strings are rotations of each other or not.\nYour code should pass this test case: assert are_Rotations(\"abc\",\"cba\") == False",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"abc\",\"cba\") == False\n    assert candidate(\"abcd\",\"cdba\") == False\n    assert candidate(\"abacd\",\"cdaba\") == True\n",
       "language": "python"
     },
     {
       "id": 651,
-      "input": "Write a function to check if one tuple is a subset of another tuple.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check if one tuple is a subset of another tuple.\nYour code should pass this test case: assert check_subset((10, 4, 5, 6), (5, 10)) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((10, 4, 5, 6), (5, 10)) == True\n    assert candidate((1, 2, 3, 4), (5, 6)) == False\n    assert candidate((7, 8, 9, 10), (10, 8)) == True\n",
       "language": "python"
     },
     {
       "id": 183,
-      "input": "Write a function to count all the distinct pairs having a difference of k in any array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to count all the distinct pairs having a difference of k in any array.\nYour code should pass this test case: assert count_pairs([1, 5, 3, 4, 2], 5, 3) == 2",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 5, 3, 4, 2], 5, 3) == 2\n    assert candidate([8, 12, 16, 4, 0, 20], 6, 4) == 5\n    assert candidate([2, 4, 1, 3, 4], 5, 2) == 3\n",
       "language": "python"
     },
     {
       "id": 691,
-      "input": "Write a function to group the 1st elements on the basis of 2nd elements in the given tuple list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to group the 1st elements on the basis of 2nd elements in the given tuple list.\nYour code should pass this test case: assert group_element([(6, 5), (2, 7), (2, 5), (8, 7), (9, 8), (3, 7)]) == {5: [6, 2], 7: [2, 8, 3], 8: [9]}",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([(6, 5), (2, 7), (2, 5), (8, 7), (9, 8), (3, 7)]) == {5: [6, 2], 7: [2, 8, 3], 8: [9]}\n    assert candidate([(7, 6), (3, 8), (3, 6), (9, 8), (10, 9), (4, 8)]) == {6: [7, 3], 8: [3, 9, 4], 9: [10]}\n    assert candidate([(8, 7), (4, 9), (4, 7), (10, 9), (11, 10), (5, 9)]) == {7: [8, 4], 9: [4, 10, 5], 10: [11]}\n",
       "language": "python"
     },
     {
       "id": 895,
-      "input": "Write a function to find the maximum sum of subsequences of given array with no adjacent elements.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the maximum sum of subsequences of given array with no adjacent elements.\nYour code should pass this test case: assert max_sum_subseq([1, 2, 9, 4, 5, 0, 4, 11, 6]) == 26",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 2, 9, 4, 5, 0, 4, 11, 6]) == 26\n    assert candidate([1, 2, 9, 5, 6, 0, 5, 12, 7]) == 28\n    assert candidate([1, 3, 10, 5, 6, 0, 6, 14, 21]) == 44\n",
       "language": "python"
     },
     {
       "id": 834,
-      "input": "Write a function to generate a square matrix filled with elements from 1 to n raised to the power of 2 in spiral order.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to generate a square matrix filled with elements from 1 to n raised to the power of 2 in spiral order.\nYour code should pass this test case: assert generate_matrix(3)==[[1, 2, 3], [8, 9, 4], [7, 6, 5]] ",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(3)==[[1, 2, 3], [8, 9, 4], [7, 6, 5]] \n    assert candidate(2)==[[1,2],[4,3]]\n    assert candidate(7)==[[1, 2, 3, 4, 5, 6, 7], [24, 25, 26, 27, 28, 29, 8], [23, 40, 41, 42, 43, 30, 9], [22, 39, 48, 49, 44, 31, 10], [21, 38, 47, 46, 45, 32, 11], [20, 37, 36, 35, 34, 33, 12], [19, 18, 17, 16, 15, 14, 13]]\n",
       "language": "python"
     },
     {
       "id": 315,
-      "input": "Write a python function to find the first maximum length of even word.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the first maximum length of even word.\nYour code should pass this test case: assert find_Max_Len_Even(\"python language\") == \"language\"",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"python language\") == \"language\"\n    assert candidate(\"maximum even length\") == \"length\"\n    assert candidate(\"eve\") == \"-1\"\n",
       "language": "python"
     },
     {
       "id": 550,
-      "input": "Write a python function to find the maximum element in a sorted and rotated array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the maximum element in a sorted and rotated array.\nYour code should pass this test case: assert find_Max([2,3,5,6,9],0,4) == 9",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([2,3,5,6,9],0,4) == 9\n    assert candidate([3,4,5,2,1],0,4) == 5\n    assert candidate([1,2,3],0,2) == 3\n",
       "language": "python"
     },
     {
       "id": 164,
-      "input": "Write a python function to check whether the sum of divisors are same or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether the sum of divisors are same or not.\nYour code should pass this test case: assert areEquivalent(36,57) == False",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(36,57) == False\n    assert candidate(2,4) == False\n    assert candidate(23,47) == True\n",
       "language": "python"
     },
     {
       "id": 2,
-      "input": "Write a function to find the similar elements from the given two tuple lists.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the similar elements from the given two tuple lists.\nYour code should pass this test case: assert similar_elements((3, 4, 5, 6),(5, 7, 4, 10)) == (4, 5)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((3, 4, 5, 6),(5, 7, 4, 10)) == (4, 5)\n    assert candidate((1, 2, 3, 4),(5, 4, 3, 7)) == (3, 4)\n    assert candidate((11, 12, 14, 13),(17, 15, 14, 13)) == (13, 14)\n",
       "language": "python"
     },
     {
       "id": 331,
-      "input": "Write a python function to count unset bits of a given number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count unset bits of a given number.\nYour code should pass this test case: assert count_unset_bits(2) == 1",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(2) == 1\n    assert candidate(4) == 2\n    assert candidate(6) == 1\n",
       "language": "python"
     },
     {
       "id": 321,
-      "input": "Write a function to find the demlo number for the given number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the demlo number for the given number.\nYour code should pass this test case: assert find_demlo(\"111111\") == '12345654321'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"111111\") == '12345654321'\n    assert candidate(\"1111\") == '1234321'\n    assert candidate(\"13333122222\") == '123456789101110987654321'\n",
       "language": "python"
     },
     {
       "id": 789,
-      "input": "Write a function to calculate the perimeter of a regular polygon.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to calculate the perimeter of a regular polygon.\nYour code should pass this test case: assert perimeter_polygon(4,20)==80",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(4,20)==80\n    assert candidate(10,15)==150\n    assert candidate(9,7)==63\n",
       "language": "python"
     },
     {
       "id": 639,
-      "input": "Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to sum the length of the names of a given list of names after removing the names that start with a lowercase letter.\nYour code should pass this test case: assert sample_nam(['sally', 'Dylan', 'rebecca', 'Diana', 'Joanne', 'keith'])==16",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(['sally', 'Dylan', 'rebecca', 'Diana', 'Joanne', 'keith'])==16\n    assert candidate([\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\"])==10\n    assert candidate([\"abcd\", \"Python\", \"abba\", \"aba\"])==6\n",
       "language": "python"
     },
     {
       "id": 455,
-      "input": "Write a function to check whether the given month number contains 31 days or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check whether the given month number contains 31 days or not.\nYour code should pass this test case: assert check_monthnumb_number(5)==True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(5)==True\n    assert candidate(2)==False\n    assert candidate(6)==False\n",
       "language": "python"
     },
     {
       "id": 82,
-      "input": "Write a function to find the volume of a sphere.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the volume of a sphere.\nYour code should pass this test case: assert volume_sphere(10)==4188.790204786391",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10)==4188.790204786391\n    assert candidate(25)==65449.84694978735\n    assert candidate(20)==33510.32163829113\n",
       "language": "python"
     },
     {
       "id": 959,
-      "input": "Write a python function to find the average of a list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the average of a list.\nYour code should pass this test case: assert Average([15, 9, 55, 41, 35, 20, 62, 49]) == 35.75",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([15, 9, 55, 41, 35, 20, 62, 49]) == 35.75\n    assert candidate([4, 5, 1, 2, 9, 7, 10, 8]) == 5.75\n    assert candidate([1,2,3]) == 2\n",
       "language": "python"
     },
     {
       "id": 738,
-      "input": "Write a function to calculate the geometric sum of n-1.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to calculate the geometric sum of n-1.\nYour code should pass this test case: assert geometric_sum(7) == 1.9921875",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(7) == 1.9921875\n    assert candidate(4) == 1.9375\n    assert candidate(8) == 1.99609375\n",
       "language": "python"
     },
     {
       "id": 475,
-      "input": "Write a function to sort counter by value.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to sort counter by value.\nYour code should pass this test case: assert sort_counter({'Math':81, 'Physics':83, 'Chemistry':87})==[('Chemistry', 87), ('Physics', 83), ('Math', 81)]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate({'Math':81, 'Physics':83, 'Chemistry':87})==[('Chemistry', 87), ('Physics', 83), ('Math', 81)]\n    assert candidate({'Math':400, 'Physics':300, 'Chemistry':250})==[('Math', 400), ('Physics', 300), ('Chemistry', 250)]\n    assert candidate({'Math':900, 'Physics':1000, 'Chemistry':1250})==[('Chemistry', 1250), ('Physics', 1000), ('Math', 900)]\n",
       "language": "python"
     },
     {
       "id": 17,
-      "input": "Write a function to find the perimeter of a square.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the perimeter of a square.\nYour code should pass this test case: assert square_perimeter(10)==40",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10)==40\n    assert candidate(5)==20\n    assert candidate(4)==16\n",
       "language": "python"
     },
     {
       "id": 658,
-      "input": "Write a function to find the item with maximum occurrences in a given list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the item with maximum occurrences in a given list.\nYour code should pass this test case: assert max_occurrences([2,3,8,4,7,9,8,2,6,5,1,6,1,2,3,4,6,9,1,2])==2",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([2,3,8,4,7,9,8,2,6,5,1,6,1,2,3,4,6,9,1,2])==2\n    assert candidate([1, 3,5, 7,1, 3,13, 15, 17,5, 7,9,1, 11])==1\n    assert candidate([1, 2, 3,2, 4, 5,1, 1, 1])==1\n",
       "language": "python"
     },
     {
       "id": 252,
-      "input": "Write a python function to convert complex numbers to polar coordinates.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to convert complex numbers to polar coordinates.\nYour code should pass this test case: assert convert(1) == (1.0, 0.0)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(1) == (1.0, 0.0)\n    assert candidate(4) == (4.0,0.0)\n    assert candidate(5) == (5.0,0.0)\n",
       "language": "python"
     },
     {
       "id": 409,
-      "input": "Write a function to find the minimum product from the pairs of tuples within a given list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the minimum product from the pairs of tuples within a given list.\nYour code should pass this test case: assert min_product_tuple([(2, 7), (2, 6), (1, 8), (4, 9)] )==8",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([(2, 7), (2, 6), (1, 8), (4, 9)] )==8\n    assert candidate([(10,20), (15,2), (5,10)] )==30\n    assert candidate([(11,44), (10,15), (20,5), (12, 9)] )==100\n",
       "language": "python"
     },
     {
       "id": 551,
-      "input": "Write a function to extract a specified column from a given nested list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to extract a specified column from a given nested list.\nYour code should pass this test case: assert extract_column([[1, 2, 3], [2, 4, 5], [1, 1, 1]],0)==[1, 2, 1]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[1, 2, 3], [2, 4, 5], [1, 1, 1]],0)==[1, 2, 1]\n    assert candidate([[1, 2, 3], [-2, 4, -5], [1, -1, 1]],2)==[3, -5, 1]\n    assert candidate([[1, 3], [5, 7], [1, 3], [13, 15, 17], [5, 7], [9, 11]],0)==[1, 5, 1, 13, 5, 9]\n",
       "language": "python"
     },
     {
       "id": 954,
-      "input": "Write a function that gives profit amount if the given amount has profit else return none.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function that gives profit amount if the given amount has profit else return none.\nYour code should pass this test case: assert profit_amount(1500,1200)==300",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(1500,1200)==300\n    assert candidate(100,200)==None\n    assert candidate(2000,5000)==None\n",
       "language": "python"
     },
     {
       "id": 246,
-      "input": "Write a function for computing square roots using the babylonian method.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function for computing square roots using the babylonian method.\nYour code should pass this test case: assert babylonian_squareroot(10)==3.162277660168379",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10)==3.162277660168379\n    assert candidate(2)==1.414213562373095\n    assert candidate(9)==3.0\n",
       "language": "python"
     },
     {
       "id": 451,
-      "input": "Write a function to remove all whitespaces from the given string using regex.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to remove all whitespaces from the given string using regex.\nYour code should pass this test case: assert remove_whitespaces(' Google    Flutter ') == 'GoogleFlutter'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(' Google    Flutter ') == 'GoogleFlutter'\n    assert candidate(' Google    Dart ') == 'GoogleDart'\n    assert candidate(' iOS    Swift ') == 'iOSSwift'\n",
       "language": "python"
     },
     {
       "id": 262,
-      "input": "Write a function to split a given list into two parts where the length of the first part of the list is given.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to split a given list into two parts where the length of the first part of the list is given.\nYour code should pass this test case: assert split_two_parts([1,1,2,3,4,4,5,1],3)==([1, 1, 2], [3, 4, 4, 5, 1])",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,1,2,3,4,4,5,1],3)==([1, 1, 2], [3, 4, 4, 5, 1])\n    assert candidate(['a', 'b', 'c', 'd'],2)==(['a', 'b'], ['c', 'd'])\n    assert candidate(['p', 'y', 't', 'h', 'o', 'n'],4)==(['p', 'y', 't', 'h'], ['o', 'n'])\n",
       "language": "python"
     },
     {
       "id": 608,
-      "input": "Write a python function to find nth bell number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find nth bell number.\nYour code should pass this test case: assert bell_Number(2) == 2",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(2) == 2\n    assert candidate(3) == 5\n    assert candidate(4) == 15\n",
       "language": "python"
     },
     {
       "id": 697,
-      "input": "Write a function to find number of even elements in the given list using lambda function.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find number of even elements in the given list using lambda function.\nYour code should pass this test case: assert count_even([1, 2, 3, 5, 7, 8, 9, 10])==3",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 2, 3, 5, 7, 8, 9, 10])==3\n    assert candidate([10,15,14,13,-18,12,-20])==5\n    assert candidate([1, 2, 4, 8, 9])==3\n",
       "language": "python"
     },
     {
       "id": 22,
-      "input": "Write a function to find the first duplicate element in a given array of integers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the first duplicate element in a given array of integers.\nYour code should pass this test case: assert find_first_duplicate(([1, 2, 3, 4, 4, 5]))==4",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(([1, 2, 3, 4, 4, 5]))==4\n    assert candidate([1, 2, 3, 4])==-1\n    assert candidate([1, 1, 2, 3, 3, 2, 2])==1\n",
       "language": "python"
     },
     {
       "id": 117,
-      "input": "Write a function to convert all possible convertible elements in the list to float.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to convert all possible convertible elements in the list to float.\nYour code should pass this test case: assert list_to_float( [(\"3\", \"4\"), (\"1\", \"26.45\"), (\"7.32\", \"8\"), (\"4\", \"8\")] ) == '[(3.0, 4.0), (1.0, 26.45), (7.32, 8.0), (4.0, 8.0)]'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate( [(\"3\", \"4\"), (\"1\", \"26.45\"), (\"7.32\", \"8\"), (\"4\", \"8\")] ) == '[(3.0, 4.0), (1.0, 26.45), (7.32, 8.0), (4.0, 8.0)]'\n    assert candidate( [(\"4\", \"4\"), (\"2\", \"27\"), (\"4.12\", \"9\"), (\"7\", \"11\")] ) == '[(4.0, 4.0), (2.0, 27.0), (4.12, 9.0), (7.0, 11.0)]'\n    assert candidate( [(\"6\", \"78\"), (\"5\", \"26.45\"), (\"1.33\", \"4\"), (\"82\", \"13\")] ) == '[(6.0, 78.0), (5.0, 26.45), (1.33, 4.0), (82.0, 13.0)]'\n",
       "language": "python"
     },
     {
       "id": 118,
-      "input": "[link text](https:// [link text](https:// [link text](https://)))write a function to convert a string to a list.",
+      "input": "You are an expert Python programmer, and here is your task: [link text](https:// [link text](https:// [link text](https://)))write a function to convert a string to a list.\nYour code should pass this test case: assert string_to_list(\"python programming\")==['python','programming']",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"python programming\")==['python','programming']\n    assert candidate(\"lists tuples strings\")==['lists','tuples','strings']\n    assert candidate(\"write a program\")==['write','a','program']\n",
       "language": "python"
     },
     {
       "id": 581,
-      "input": "Write a python function to find the surface area of the square pyramid.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the surface area of the square pyramid.\nYour code should pass this test case: assert surface_Area(3,4) == 33",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(3,4) == 33\n    assert candidate(4,5) == 56\n    assert candidate(1,2) == 5\n",
       "language": "python"
     },
     {
       "id": 128,
-      "input": "Write a function to shortlist words that are longer than n from a given list of words.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to shortlist words that are longer than n from a given list of words.\nYour code should pass this test case: assert long_words(3,\"python is a programming language\")==['python','programming','language']",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(3,\"python is a programming language\")==['python','programming','language']\n    assert candidate(2,\"writing a program\")==['writing','program']\n    assert candidate(5,\"sorting list\")==['sorting']\n",
       "language": "python"
     },
     {
       "id": 583,
-      "input": "Write a function for nth catalan number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function for nth catalan number.\nYour code should pass this test case: assert catalan_number(10)==16796",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10)==16796\n    assert candidate(9)==4862\n    assert candidate(7)==429\n",
       "language": "python"
     },
     {
       "id": 477,
-      "input": "Write a python function to convert the given string to lower case.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to convert the given string to lower case.\nYour code should pass this test case: assert is_lower(\"InValid\") == \"invalid\"",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"InValid\") == \"invalid\"\n    assert candidate(\"TruE\") == \"true\"\n    assert candidate(\"SenTenCE\") == \"sentence\"\n",
       "language": "python"
     },
     {
       "id": 647,
-      "input": "Write a function to split a string at uppercase letters.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to split a string at uppercase letters.\nYour code should pass this test case: assert split_upperstring(\"PythonProgramLanguage\")==['Python','Program','Language']",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"PythonProgramLanguage\")==['Python','Program','Language']\n    assert candidate(\"PythonProgram\")==['Python','Program']\n    assert candidate(\"ProgrammingLanguage\")==['Programming','Language']\n",
       "language": "python"
     },
     {
       "id": 605,
-      "input": "Write a function to check if the given integer is a prime number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check if the given integer is a prime number.\nYour code should pass this test case: assert prime_num(13)==True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(13)==True\n    assert candidate(7)==True\n    assert candidate(-1010)==False\n",
       "language": "python"
     },
     {
       "id": 115,
-      "input": "Write a function to check whether all dictionaries in a list are empty or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check whether all dictionaries in a list are empty or not.\nYour code should pass this test case: assert empty_dit([{},{},{}])==True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([{},{},{}])==True\n    assert candidate([{1,2},{},{}])==False\n    assert candidate({})==True\n",
       "language": "python"
     },
     {
       "id": 510,
-      "input": "Write a function to find the number of subsequences having product smaller than k for the given non negative array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the number of subsequences having product smaller than k for the given non negative array.\nYour code should pass this test case: assert no_of_subsequences([1,2,3,4], 10) == 11",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,3,4], 10) == 11\n    assert candidate([4,8,7,2], 50) == 9\n    assert candidate([5,6,7,8], 15) == 4\n",
       "language": "python"
     },
     {
       "id": 814,
-      "input": "Write a function to find the area of a rombus.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the area of a rombus.\nYour code should pass this test case: assert rombus_area(10,20)==100",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10,20)==100\n    assert candidate(10,5)==25\n    assert candidate(4,2)==4\n",
       "language": "python"
     },
     {
       "id": 47,
-      "input": "Write a python function to find the last digit when factorial of a divides factorial of b.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the last digit when factorial of a divides factorial of b.\nYour code should pass this test case: assert compute_Last_Digit(2,4) == 2",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(2,4) == 2\n    assert candidate(6,8) == 6\n    assert candidate(1,2) == 2\n    assert candidate(3,7) == 0\n    assert candidate(20,23) == 6\n    assert candidate(1021,1024) == 4\n",
       "language": "python"
     },
     {
       "id": 413,
-      "input": "Write a function to extract the nth element from a given list of tuples.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to extract the nth element from a given list of tuples.\nYour code should pass this test case: assert extract_nth_element([('Greyson Fulton', 98, 99), ('Brady Kent', 97, 96), ('Wyatt Knott', 91, 94), ('Beau Turnbull', 94, 98)] ,0)==['Greyson Fulton', 'Brady Kent', 'Wyatt Knott', 'Beau Turnbull']",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([('Greyson Fulton', 98, 99), ('Brady Kent', 97, 96), ('Wyatt Knott', 91, 94), ('Beau Turnbull', 94, 98)] ,0)==['Greyson Fulton', 'Brady Kent', 'Wyatt Knott', 'Beau Turnbull']\n    assert candidate([('Greyson Fulton', 98, 99), ('Brady Kent', 97, 96), ('Wyatt Knott', 91, 94), ('Beau Turnbull', 94, 98)] ,2)==[99, 96, 94, 98]\n    assert candidate([('Greyson Fulton', 98, 99), ('Brady Kent', 97, 96), ('Wyatt Knott', 91, 94), ('Beau Turnbull', 94, 98)],1)==[98, 97, 91, 94]\n",
       "language": "python"
     },
     {
       "id": 448,
-      "input": "Write a function to calculate the sum of perrin numbers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to calculate the sum of perrin numbers.\nYour code should pass this test case: assert cal_sum(9) == 49",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(9) == 49\n    assert candidate(10) == 66\n    assert candidate(11) == 88\n",
       "language": "python"
     },
     {
       "id": 412,
-      "input": "Write a python function to remove odd numbers from a given list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to remove odd numbers from a given list.\nYour code should pass this test case: assert remove_odd([1,2,3]) == [2]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,3]) == [2]\n    assert candidate([2,4,6]) == [2,4,6]\n    assert candidate([10,20,3]) == [10,20]\n",
       "language": "python"
     },
     {
       "id": 512,
-      "input": "Write a function to count the element frequency in the mixed nested tuple.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to count the element frequency in the mixed nested tuple.\nYour code should pass this test case: assert count_element_freq((5, 6, (5, 6), 7, (8, 9), 9) ) == {5: 2, 6: 2, 7: 1, 8: 1, 9: 2}",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((5, 6, (5, 6), 7, (8, 9), 9) ) == {5: 2, 6: 2, 7: 1, 8: 1, 9: 2}\n    assert candidate((6, 7, (6, 7), 8, (9, 10), 10) ) == {6: 2, 7: 2, 8: 1, 9: 1, 10: 2}\n    assert candidate((7, 8, (7, 8), 9, (10, 11), 11) ) == {7: 2, 8: 2, 9: 1, 10: 1, 11: 2}\n",
       "language": "python"
     },
     {
       "id": 354,
-      "input": "Write a function to find t-nth term of arithemetic progression.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find t-nth term of arithemetic progression.\nYour code should pass this test case: assert tn_ap(1,5,2)==9",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(1,5,2)==9\n    assert candidate(2,6,4)==22\n    assert candidate(1,4,5)==16\n",
       "language": "python"
     },
     {
       "id": 199,
-      "input": "Write a python function to find highest power of 2 less than or equal to given number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find highest power of 2 less than or equal to given number.\nYour code should pass this test case: assert highest_Power_of_2(10) == 8",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10) == 8\n    assert candidate(19) == 16\n    assert candidate(32) == 32\n",
       "language": "python"
     },
     {
       "id": 787,
-      "input": "Write a function that matches a string that has an a followed by three 'b'.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function that matches a string that has an a followed by three 'b'.\nYour code should pass this test case: assert text_match_three(\"ac\")==('Not matched!')",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"ac\")==('Not matched!')\n    assert candidate(\"dc\")==('Not matched!')\n    assert candidate(\"abbbba\")==('Found a match!')\n",
       "language": "python"
     },
     {
       "id": 73,
-      "input": "Write a function to split the given string with multiple delimiters by using regex.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to split the given string with multiple delimiters by using regex.\nYour code should pass this test case: assert multiple_split('Forces of the \\ndarkness*are coming into the play.') == ['Forces of the ', 'darkness', 'are coming into the play.']",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('Forces of the \\ndarkness*are coming into the play.') == ['Forces of the ', 'darkness', 'are coming into the play.']\n    assert candidate('Mi Box runs on the \\n Latest android*which has google assistance and chromecast.') == ['Mi Box runs on the ', ' Latest android', 'which has google assistance and chromecast.']\n    assert candidate('Certain services\\nare subjected to change*over the seperate subscriptions.') == ['Certain services', 'are subjected to change', 'over the seperate subscriptions.']\n",
       "language": "python"
     },
     {
       "id": 391,
-      "input": "Write a function to convert more than one list to nested dictionary.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to convert more than one list to nested dictionary.\nYour code should pass this test case: assert convert_list_dictionary([\"S001\", \"S002\", \"S003\", \"S004\"],[\"Adina Park\", \"Leyton Marsh\", \"Duncan Boyle\", \"Saim Richards\"] ,[85, 98, 89, 92])==[{'S001': {'Adina Park': 85}}, {'S002': {'Leyton Marsh': 98}}, {'S003': {'Duncan Boyle': 89}}, {'S004': {'Saim Richards': 92}}]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([\"S001\", \"S002\", \"S003\", \"S004\"],[\"Adina Park\", \"Leyton Marsh\", \"Duncan Boyle\", \"Saim Richards\"] ,[85, 98, 89, 92])==[{'S001': {'Adina Park': 85}}, {'S002': {'Leyton Marsh': 98}}, {'S003': {'Duncan Boyle': 89}}, {'S004': {'Saim Richards': 92}}]\n    assert candidate([\"abc\",\"def\",\"ghi\",\"jkl\"],[\"python\",\"program\",\"language\",\"programs\"],[100,200,300,400])==[{'abc':{'python':100}},{'def':{'program':200}},{'ghi':{'language':300}},{'jkl':{'programs':400}}]\n    assert candidate([\"A1\",\"A2\",\"A3\",\"A4\"],[\"java\",\"C\",\"C++\",\"DBMS\"],[10,20,30,40])==[{'A1':{'java':10}},{'A2':{'C':20}},{'A3':{'C++':30}},{'A4':{'DBMS':40}}]\n",
       "language": "python"
     },
     {
       "id": 485,
-      "input": "Write a function to find the largest palindromic number in the given array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the largest palindromic number in the given array.\nYour code should pass this test case: assert largest_palindrome([1, 232, 54545, 999991], 4) == 54545",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 232, 54545, 999991], 4) == 54545\n    assert candidate([1, 2, 3, 4, 5, 50], 6) == 5\n    assert candidate([1, 3, 7, 9, 45], 5)  == 9\n",
       "language": "python"
     },
     {
       "id": 176,
-      "input": "Write a function to find the perimeter of a triangle.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the perimeter of a triangle.\nYour code should pass this test case: assert perimeter_triangle(10,20,30)==60",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10,20,30)==60\n    assert candidate(3,4,5)==12\n    assert candidate(25,35,45)==105\n",
       "language": "python"
     },
     {
       "id": 74,
-      "input": "Write a function to check whether it follows the sequence given in the patterns array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check whether it follows the sequence given in the patterns array.\nYour code should pass this test case: assert is_samepatterns([\"red\",\"green\",\"green\"], [\"a\", \"b\", \"b\"])==True ",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([\"red\",\"green\",\"green\"], [\"a\", \"b\", \"b\"])==True \n    assert candidate([\"red\",\"green\",\"greenn\"], [\"a\",\"b\",\"b\"])==False \n    assert candidate([\"red\",\"green\",\"greenn\"], [\"a\",\"b\"])==False \n",
       "language": "python"
     },
     {
       "id": 51,
-      "input": "Write a function to print check if the triangle is equilateral or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to print check if the triangle is equilateral or not.\nYour code should pass this test case: assert check_equilateral(6,8,12)==False ",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(6,8,12)==False \n    assert candidate(6,6,12)==False\n    assert candidate(6,6,6)==True\n",
       "language": "python"
     },
     {
       "id": 283,
-      "input": "Write a python function to check whether the frequency of each digit is less than or equal to the digit itself.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether the frequency of each digit is less than or equal to the digit itself.\nYour code should pass this test case: assert validate(1234) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(1234) == True\n    assert candidate(51241) == False\n    assert candidate(321) == True\n",
       "language": "python"
     },
     {
       "id": 556,
-      "input": "Write a python function to count the pairs with xor as an odd number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count the pairs with xor as an odd number.\nYour code should pass this test case: assert find_Odd_Pair([5,4,7,2,1],5) == 6",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([5,4,7,2,1],5) == 6\n    assert candidate([7,2,8,1,0,5,11],7) == 12\n    assert candidate([1,2,3],3) == 2\n",
       "language": "python"
     },
     {
       "id": 673,
-      "input": "Write a python function to convert a list of multiple integers into a single integer.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to convert a list of multiple integers into a single integer.\nYour code should pass this test case: assert convert([1,2,3]) == 123",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,3]) == 123\n    assert candidate([4,5,6]) == 456\n    assert candidate([7,8,9]) == 789\n",
       "language": "python"
     },
     {
       "id": 318,
-      "input": "Write a python function to find the maximum volume of a cuboid with given sum of sides.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the maximum volume of a cuboid with given sum of sides.\nYour code should pass this test case: assert max_volume(8) == 18",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(8) == 18\n    assert candidate(4) == 2\n    assert candidate(1) == 0\n",
       "language": "python"
     },
     {
       "id": 901,
-      "input": "Write a function to find the smallest multiple of the first n numbers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the smallest multiple of the first n numbers.\nYour code should pass this test case: assert smallest_multiple(13)==360360",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(13)==360360\n    assert candidate(2)==2\n    assert candidate(1)==1\n",
       "language": "python"
     },
     {
       "id": 709,
-      "input": "Write a function to count unique keys for each value present in the tuple.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to count unique keys for each value present in the tuple.\nYour code should pass this test case: assert get_unique([(3, 4), (1, 2), (2, 4), (8, 2), (7, 2), (8, 1), (9, 1), (8, 4), (10, 4)] ) == '{4: 4, 2: 3, 1: 2}'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([(3, 4), (1, 2), (2, 4), (8, 2), (7, 2), (8, 1), (9, 1), (8, 4), (10, 4)] ) == '{4: 4, 2: 3, 1: 2}'\n    assert candidate([(4, 5), (2, 3), (3, 5), (9, 3), (8, 3), (9, 2), (10, 2), (9, 5), (11, 5)] ) == '{5: 4, 3: 3, 2: 2}'\n    assert candidate([(6, 5), (3, 4), (2, 6), (11, 1), (8, 22), (8, 11), (4, 3), (14, 3), (11, 6)] ) == '{5: 1, 4: 1, 6: 2, 1: 1, 22: 1, 11: 1, 3: 2}'\n",
       "language": "python"
     },
     {
       "id": 132,
-      "input": "Write a function to convert tuple to a string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to convert tuple to a string.\nYour code should pass this test case: assert tup_string(('e', 'x', 'e', 'r', 'c', 'i', 's', 'e', 's'))==(\"exercises\")",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(('e', 'x', 'e', 'r', 'c', 'i', 's', 'e', 's'))==(\"exercises\")\n    assert candidate(('p','y','t','h','o','n'))==(\"python\")\n    assert candidate(('p','r','o','g','r','a','m'))==(\"program\")\n",
       "language": "python"
     },
     {
       "id": 912,
-      "input": "Write a function to find ln, m lobb number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find ln, m lobb number.\nYour code should pass this test case: assert int(lobb_num(5, 3)) == 35",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(lobb_num(5, 3)) == 35\n    assert candidate(lobb_num(3, 2)) == 5\n    assert candidate(lobb_num(4, 2)) == 20\n",
       "language": "python"
     },
     {
       "id": 516,
-      "input": "Write a function to sort a list of elements using radix sort.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to sort a list of elements using radix sort.\nYour code should pass this test case: assert radix_sort([15, 79, 25, 68, 37]) == [15, 25, 37, 68, 79]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([15, 79, 25, 68, 37]) == [15, 25, 37, 68, 79]\n    assert candidate([9, 11, 8, 7, 3, 2]) == [2, 3, 7, 8, 9, 11]\n    assert candidate([36, 12, 24, 26, 29]) == [12, 24, 26, 29, 36]\n",
       "language": "python"
     },
     {
       "id": 508,
-      "input": "Write a function to check if the common elements between two given lists are in the same order or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check if the common elements between two given lists are in the same order or not.\nYour code should pass this test case: assert same_order([\"red\",\"green\",\"black\",\"orange\"],[\"red\",\"pink\",\"green\",\"white\",\"black\"])==True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([\"red\",\"green\",\"black\",\"orange\"],[\"red\",\"pink\",\"green\",\"white\",\"black\"])==True\n    assert candidate([\"red\",\"pink\",\"green\",\"white\",\"black\"],[\"white\",\"orange\",\"pink\",\"black\"])==False\n    assert candidate([\"red\",\"green\",\"black\",\"orange\"],[\"red\",\"pink\",\"green\",\"white\",\"black\"])==True\n",
       "language": "python"
     },
     {
       "id": 870,
-      "input": "Write a function to calculate the sum of the positive numbers of a given list of numbers using lambda function.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to calculate the sum of the positive numbers of a given list of numbers using lambda function.\nYour code should pass this test case: assert sum_positivenum([2, 4, -6, -9, 11, -12, 14, -5, 17])==48",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([2, 4, -6, -9, 11, -12, 14, -5, 17])==48\n    assert candidate([10,15,-14,13,-18,12,-20])==50\n    assert candidate([19, -65, 57, 39, 152,-639, 121, 44, 90, -190])==522\n",
       "language": "python"
     },
     {
       "id": 517,
-      "input": "Write a python function to find the largest postive number from the given list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the largest postive number from the given list.\nYour code should pass this test case: assert largest_pos([1,2,3,4,-1]) == 4",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,3,4,-1]) == 4\n    assert candidate([0,1,2,-5,-1,6]) == 6\n    assert candidate([0,0,1,0]) == 1\n",
       "language": "python"
     },
     {
       "id": 930,
-      "input": "Write a function that matches a string that has an a followed by zero or more b's by using regex.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function that matches a string that has an a followed by zero or more b's by using regex.\nYour code should pass this test case: assert text_match(\"msb\") == 'Not matched!'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"msb\") == 'Not matched!'\n    assert candidate(\"a0c\") == 'Found a match!'\n    assert candidate(\"abbc\") == 'Found a match!'\n",
       "language": "python"
     },
     {
       "id": 223,
-      "input": "Write a function to check for majority element in the given sorted array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check for majority element in the given sorted array.\nYour code should pass this test case: assert is_majority([1, 2, 3, 3, 3, 3, 10], 7, 3) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 2, 3, 3, 3, 3, 10], 7, 3) == True\n    assert candidate([1, 1, 2, 4, 4, 4, 6, 6], 8, 4) == False\n    assert candidate([1, 1, 1, 2, 2], 5, 1) == True\n",
       "language": "python"
     },
     {
       "id": 832,
-      "input": "Write a function to extract the maximum numeric value from a string by using regex.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to extract the maximum numeric value from a string by using regex.\nYour code should pass this test case: assert extract_max('100klh564abc365bg') == 564",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('100klh564abc365bg') == 564\n    assert candidate('hello300how546mer231') == 546\n    assert candidate('its233beenalong343journey234') == 343\n",
       "language": "python"
     },
     {
       "id": 344,
-      "input": "Write a python function to find number of elements with odd factors in a given range.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find number of elements with odd factors in a given range.\nYour code should pass this test case: assert count_Odd_Squares(5,100) == 8",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(5,100) == 8\n    assert candidate(8,65) == 6\n    assert candidate(2,5) == 1\n",
       "language": "python"
     },
     {
       "id": 886,
-      "input": "Write a function to add all the numbers in a list and divide it with the length of the list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to add all the numbers in a list and divide it with the length of the list.\nYour code should pass this test case: assert sum_num((8, 2, 3, 0, 7))==4.0",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((8, 2, 3, 0, 7))==4.0\n    assert candidate((-10,-20,-30))==-20.0\n    assert candidate((19,15,18))==17.333333333333332\n",
       "language": "python"
     },
     {
       "id": 921,
-      "input": "Write a function to perform chunking of tuples each of size n.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to perform chunking of tuples each of size n.\nYour code should pass this test case: assert chunk_tuples((10, 4, 5, 6, 7, 6, 8, 3, 4), 3) == [(10, 4, 5), (6, 7, 6), (8, 3, 4)]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((10, 4, 5, 6, 7, 6, 8, 3, 4), 3) == [(10, 4, 5), (6, 7, 6), (8, 3, 4)]\n    assert candidate((1, 2, 3, 4, 5, 6, 7, 8, 9), 2) == [(1, 2), (3, 4), (5, 6), (7, 8), (9,)]\n    assert candidate((11, 14, 16, 17, 19, 21, 22, 25), 4) == [(11, 14, 16, 17), (19, 21, 22, 25)]\n",
       "language": "python"
     },
     {
       "id": 820,
-      "input": "Write a function to check whether the given month number contains 28 days or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check whether the given month number contains 28 days or not.\nYour code should pass this test case: assert check_monthnum_number(2)==True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(2)==True\n    assert candidate(1)==False\n    assert candidate(3)==False\n",
       "language": "python"
     },
     {
       "id": 166,
-      "input": "Write a python function to count the pairs with xor as an even number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count the pairs with xor as an even number.\nYour code should pass this test case: assert find_even_Pair([5,4,7,2,1],5) == 4",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([5,4,7,2,1],5) == 4\n    assert candidate([7,2,8,1,0,5,11],7) == 9\n    assert candidate([1,2,3],3) == 1\n",
       "language": "python"
     },
     {
       "id": 382,
-      "input": "Write a function to find the number of rotations in a circularly sorted array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the number of rotations in a circularly sorted array.\nYour code should pass this test case: assert find_rotation_count([8, 9, 10, 1, 2, 3, 4, 5, 6, 7]) == 3",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([8, 9, 10, 1, 2, 3, 4, 5, 6, 7]) == 3\n    assert candidate([8, 9, 10,2, 5, 6]) == 3\n    assert candidate([2, 5, 6, 8, 9, 10]) == 0\n",
       "language": "python"
     },
     {
       "id": 908,
-      "input": "Write a function to find the fixed point in the given array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the fixed point in the given array.\nYour code should pass this test case: assert find_fixed_point([-10, -1, 0, 3, 10, 11, 30, 50, 100],9) == 3",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([-10, -1, 0, 3, 10, 11, 30, 50, 100],9) == 3\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8],8) == -1\n    assert candidate([0, 2, 5, 8, 17],5) == 0\n",
       "language": "python"
     },
     {
       "id": 245,
-      "input": "Write a function to find the maximum sum of bi-tonic sub-sequence for the given array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the maximum sum of bi-tonic sub-sequence for the given array.\nYour code should pass this test case: assert max_sum([1, 15, 51, 45, 33, 100, 12, 18, 9], 9) == 194",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 15, 51, 45, 33, 100, 12, 18, 9], 9) == 194\n    assert candidate([80, 60, 30, 40, 20, 10], 6) == 210\n    assert candidate([2, 3 ,14, 16, 21, 23, 29, 30], 8) == 138\n",
       "language": "python"
     },
     {
       "id": 221,
-      "input": "Write a python function to find the first even number in a given list of numbers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the first even number in a given list of numbers.\nYour code should pass this test case: assert first_even ([1, 3, 5, 7, 4, 1, 6, 8]) == 4",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 3, 5, 7, 4, 1, 6, 8]) == 4\n    assert candidate([2, 3, 4]) == 2\n    assert candidate([5, 6, 7]) == 6\n",
       "language": "python"
     },
     {
       "id": 906,
-      "input": "Write a function to extract year, month and date from a url by using regex.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to extract year, month and date from a url by using regex.\nYour code should pass this test case: assert extract_date(\"https://www.washingtonpost.com/news/football-insider/wp/2016/09/02/odell-beckhams-fame-rests-on-one-stupid-little-ball-josh-norman-tells-author/\") == [('2016', '09', '02')]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"https://www.washingtonpost.com/news/football-insider/wp/2016/09/02/odell-beckhams-fame-rests-on-one-stupid-little-ball-josh-norman-tells-author/\") == [('2016', '09', '02')]\n    assert candidate(\"https://www.indiatoday.in/movies/celebrities/story/wp/2020/11/03/odeof-sushant-singh-rajput-s-death-his-brother-in-law-shares-advice-for-fans-1749646/\") == [('2020', '11', '03')]\n    assert candidate(\"https://economictimes.indiatimes.com/news/economy/2020/12/29/finance/pension-assets-under-pfrda-touch-rs-5-32-lakh-crore/articleshow/79736619.cms\") == [('2020', '12', '29')]\n",
       "language": "python"
     },
     {
       "id": 12,
-      "input": "Write a function to sort a given matrix in ascending order according to the sum of its rows.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to sort a given matrix in ascending order according to the sum of its rows.\nYour code should pass this test case: assert sort_matrix([[1, 2, 3], [2, 4, 5], [1, 1, 1]])==[[1, 1, 1], [1, 2, 3], [2, 4, 5]]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[1, 2, 3], [2, 4, 5], [1, 1, 1]])==[[1, 1, 1], [1, 2, 3], [2, 4, 5]]\n    assert candidate([[1, 2, 3], [-2, 4, -5], [1, -1, 1]])==[[-2, 4, -5], [1, -1, 1], [1, 2, 3]]\n    assert candidate([[5,8,9],[6,4,3],[2,1,4]])==[[2, 1, 4], [6, 4, 3], [5, 8, 9]]\n",
       "language": "python"
     },
     {
       "id": 1,
-      "input": "Write a function to find the minimum cost path to reach (m, n) from (0, 0) for the given cost matrix cost[][] and a position (m, n) in cost[][].",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the minimum cost path to reach (m, n) from (0, 0) for the given cost matrix cost[][] and a position (m, n) in cost[][].\nYour code should pass this test case: assert min_cost([[1, 2, 3], [4, 8, 2], [1, 5, 3]], 2, 2) == 8",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[1, 2, 3], [4, 8, 2], [1, 5, 3]], 2, 2) == 8\n    assert candidate([[2, 3, 4], [5, 9, 3], [2, 6, 4]], 2, 2) == 12\n    assert candidate([[3, 4, 5], [6, 10, 4], [3, 7, 5]], 2, 2) == 16\n",
       "language": "python"
     },
     {
       "id": 139,
-      "input": "Write a function to find the circumference of a circle.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the circumference of a circle.\nYour code should pass this test case: assert circle_circumference(10)==62.830000000000005",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10)==62.830000000000005\n    assert candidate(5)==31.415000000000003\n    assert candidate(4)==25.132\n",
       "language": "python"
     },
     {
       "id": 943,
-      "input": "Write a function to combine two given sorted lists using heapq module.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to combine two given sorted lists using heapq module.\nYour code should pass this test case: assert combine_lists([1, 3, 5, 7, 9, 11],[0, 2, 4, 6, 8, 10])==[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 3, 5, 7, 9, 11],[0, 2, 4, 6, 8, 10])==[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]\n    assert candidate([1, 3, 5, 6, 8, 9], [2, 5, 7, 11])==[1,2,3,5,5,6,7,8,9,11]\n    assert candidate([1,3,7],[2,4,6])==[1,2,3,4,6,7]\n",
       "language": "python"
     },
     {
       "id": 838,
-      "input": "Write a python function to find minimum number swaps required to make two binary strings equal.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find minimum number swaps required to make two binary strings equal.\nYour code should pass this test case: assert min_Swaps(\"0011\",\"1111\") == 1",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"0011\",\"1111\") == 1\n    assert candidate(\"00011\",\"01001\") == 2\n    assert candidate(\"111\",\"111\") == 0\n",
       "language": "python"
     },
     {
       "id": 534,
-      "input": "Write a function to search a literals string in a string and also find the location within the original string where the pattern occurs.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to search a literals string in a string and also find the location within the original string where the pattern occurs.\nYour code should pass this test case: assert search_literal('python','python programming language')==(0,6)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('python','python programming language')==(0,6)\n    assert candidate('programming','python programming language')==(7,18)\n    assert candidate('language','python programming language')==(19,27)\n",
       "language": "python"
     },
     {
       "id": 836,
-      "input": "Write a function to find length of the subarray having maximum sum.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find length of the subarray having maximum sum.\nYour code should pass this test case: assert max_sub_array_sum([-2, -3, 4, -1, -2, 1, 5, -3],8) == 5",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([-2, -3, 4, -1, -2, 1, 5, -3],8) == 5\n    assert candidate([1, -2, 1, 1, -2, 1],6) == 2\n    assert candidate([-1, -2, 3, 4, 5],5) == 3\n",
       "language": "python"
     },
     {
       "id": 624,
-      "input": "Write a python function to convert the given string to upper case.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to convert the given string to upper case.\nYour code should pass this test case: assert is_upper(\"person\") ==\"PERSON\"",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"person\") ==\"PERSON\"\n    assert candidate(\"final\") == \"FINAL\"\n    assert candidate(\"Valid\") == \"VALID\"\n",
       "language": "python"
     },
     {
       "id": 924,
-      "input": "Write a function to find maximum of two numbers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find maximum of two numbers.\nYour code should pass this test case: assert max_of_two(10,20)==20",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10,20)==20\n    assert candidate(19,15)==19\n    assert candidate(-10,-20)==-10\n",
       "language": "python"
     },
     {
       "id": 64,
-      "input": "Write a function to sort a list of tuples using lambda.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to sort a list of tuples using lambda.\nYour code should pass this test case: assert subject_marks([('English', 88), ('Science', 90), ('Maths', 97), ('Social sciences', 82)])==[('Social sciences', 82), ('English', 88), ('Science', 90), ('Maths', 97)]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([('English', 88), ('Science', 90), ('Maths', 97), ('Social sciences', 82)])==[('Social sciences', 82), ('English', 88), ('Science', 90), ('Maths', 97)]\n    assert candidate([('Telugu',49),('Hindhi',54),('Social',33)])==([('Social',33),('Telugu',49),('Hindhi',54)])\n    assert candidate([('Physics',96),('Chemistry',97),('Biology',45)])==([('Biology',45),('Physics',96),('Chemistry',97)])\n",
       "language": "python"
     },
     {
       "id": 880,
-      "input": "Write a python function to find number of solutions in quadratic equation.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find number of solutions in quadratic equation.\nYour code should pass this test case: assert Check_Solution(2,5,2) == \"2 solutions\"",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(2,5,2) == \"2 solutions\"\n    assert candidate(1,1,1) == \"No solutions\"\n    assert candidate(1,2,1) == \"1 solution\"\n",
       "language": "python"
     },
     {
       "id": 84,
-      "input": "Write a function to find the n-th number in newman conway sequence.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the n-th number in newman conway sequence.\nYour code should pass this test case: assert sequence(10) == 6",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10) == 6\n    assert candidate(2) == 1\n    assert candidate(3) == 2\n",
       "language": "python"
     },
     {
       "id": 208,
-      "input": "Write a function to check the given decimal with a precision of 2 by using regex.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check the given decimal with a precision of 2 by using regex.\nYour code should pass this test case: assert is_decimal('123.11') == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('123.11') == True\n    assert candidate('0.21') == True\n    assert candidate('123.1214') == False\n",
       "language": "python"
     },
     {
       "id": 682,
-      "input": "Write a function to multiply two lists using map and lambda function.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to multiply two lists using map and lambda function.\nYour code should pass this test case: assert mul_list([1, 2, 3],[4,5,6])==[4,10,18]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 2, 3],[4,5,6])==[4,10,18]\n    assert candidate([1,2],[3,4])==[3,8]\n    assert candidate([90,120],[50,70])==[4500,8400]\n",
       "language": "python"
     },
     {
       "id": 604,
-      "input": "Write a function to reverse words in a given string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to reverse words in a given string.\nYour code should pass this test case: assert reverse_words(\"python program\")==(\"program python\")",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"python program\")==(\"program python\")\n    assert candidate(\"java language\")==(\"language java\")\n    assert candidate(\"indian man\")==(\"man indian\")\n",
       "language": "python"
     },
     {
       "id": 867,
-      "input": "Write a python function to add a minimum number such that the sum of array becomes even.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to add a minimum number such that the sum of array becomes even.\nYour code should pass this test case: assert min_Num([1,2,3,4,5,6,7,8,9],9) == 1",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,3,4,5,6,7,8,9],9) == 1\n    assert candidate([1,2,3,4,5,6,7,8],8) == 2\n    assert candidate([1,2,3],3) == 2\n",
       "language": "python"
     },
     {
       "id": 931,
-      "input": "Write a function to calculate the sum of series 1\u00b3+2\u00b3+3\u00b3+\u2026.+n\u00b3.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to calculate the sum of series 1\u00b3+2\u00b3+3\u00b3+\u2026.+n\u00b3.\nYour code should pass this test case: assert sum_series(7)==784",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(7)==784\n    assert candidate(5)==225\n    assert candidate(15)==14400\n",
       "language": "python"
     },
     {
       "id": 703,
-      "input": "Write a function to check whether the given key is present in the dictionary or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check whether the given key is present in the dictionary or not.\nYour code should pass this test case: assert is_key_present({1: 10, 2: 20, 3: 30, 4: 40, 5: 50, 6: 60},5)==True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate({1: 10, 2: 20, 3: 30, 4: 40, 5: 50, 6: 60},5)==True\n    assert candidate({1: 10, 2: 20, 3: 30, 4: 40, 5: 50, 6: 60},6)==True\n    assert candidate({1: 10, 2: 20, 3: 30, 4: 40, 5: 50, 6: 60},10)==False\n",
       "language": "python"
     },
     {
       "id": 723,
-      "input": "Write a function to count the same pair in two given lists using map function.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to count the same pair in two given lists using map function.\nYour code should pass this test case: assert count_same_pair([1, 2, 3, 4, 5, 6, 7, 8],[2, 2, 3, 1, 2, 6, 7, 9])==4",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8],[2, 2, 3, 1, 2, 6, 7, 9])==4\n    assert candidate([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8],[2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8])==11\n    assert candidate([2, 4, -6, -9, 11, -12, 14, -5, 17],[2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8])==1\n",
       "language": "python"
     },
     {
       "id": 897,
-      "input": "Write a python function to check whether the word is present in a given sentence or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether the word is present in a given sentence or not.\nYour code should pass this test case: assert is_Word_Present(\"machine learning\",\"machine\") == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"machine learning\",\"machine\") == True\n    assert candidate(\"easy\",\"fun\") == False\n    assert candidate(\"python language\",\"code\") == False\n",
       "language": "python"
     },
     {
       "id": 20,
-      "input": "Write a function to check if the given number is woodball or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check if the given number is woodball or not.\nYour code should pass this test case: assert is_woodall(383) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(383) == True\n    assert candidate(254) == False\n    assert candidate(200) == False\n    assert candidate(32212254719) == True\n    assert candidate(32212254718) == False\n    assert candidate(159) == True\n",
       "language": "python"
     },
     {
       "id": 960,
-      "input": "Write a function to solve tiling problem.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to solve tiling problem.\nYour code should pass this test case: assert get_noOfways(4)==3",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(4)==3\n    assert candidate(3)==2\n    assert candidate(5)==5\n",
       "language": "python"
     },
     {
       "id": 531,
-      "input": "Write a function to find minimum number of coins that make a given value.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find minimum number of coins that make a given value.\nYour code should pass this test case: assert min_coins([9, 6, 5, 1] ,4,11)==2",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([9, 6, 5, 1] ,4,11)==2\n    assert candidate([4,5,6,7,8,9],6,9)==1\n    assert candidate([1, 2, 3],3,4)==2\n",
       "language": "python"
     },
     {
       "id": 766,
-      "input": "Write a function to iterate over all pairs of consecutive items in a given list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to iterate over all pairs of consecutive items in a given list.\nYour code should pass this test case: assert pair_wise([1,1,2,3,3,4,4,5])==[(1, 1), (1, 2), (2, 3), (3, 3), (3, 4), (4, 4), (4, 5)]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,1,2,3,3,4,4,5])==[(1, 1), (1, 2), (2, 3), (3, 3), (3, 4), (4, 4), (4, 5)]\n    assert candidate([1,5,7,9,10])==[(1, 5), (5, 7), (7, 9), (9, 10)]\n    assert candidate([1,2,3,4,5,6,7,8,9,10])==[(1, 2), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7), (7, 8), (8, 9), (9, 10)]\n",
       "language": "python"
     },
     {
       "id": 848,
-      "input": "Write a function to find the area of a trapezium.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the area of a trapezium.\nYour code should pass this test case: assert area_trapezium(6,9,4)==30",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(6,9,4)==30\n    assert candidate(10,20,30)==450\n    assert candidate(15,25,35)==700\n",
       "language": "python"
     },
     {
       "id": 205,
-      "input": "Write a function to find the inversions of tuple elements in the given tuple list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the inversions of tuple elements in the given tuple list.\nYour code should pass this test case: assert inversion_elements((7, 8, 9, 1, 10, 7)) == (-8, -9, -10, -2, -11, -8)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((7, 8, 9, 1, 10, 7)) == (-8, -9, -10, -2, -11, -8)\n    assert candidate((2, 4, 5, 6, 1, 7)) == (-3, -5, -6, -7, -2, -8)\n    assert candidate((8, 9, 11, 14, 12, 13)) == (-9, -10, -12, -15, -13, -14)\n",
       "language": "python"
     },
     {
       "id": 153,
-      "input": "Write a function to find the vertex of a parabola.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the vertex of a parabola.\nYour code should pass this test case: assert parabola_vertex(5,3,2)==(-0.3, 1.55)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(5,3,2)==(-0.3, 1.55)\n    assert candidate(9,8,4)==(-0.4444444444444444, 2.2222222222222223)\n    assert candidate(2,4,6)==(-1.0, 4.0)\n",
       "language": "python"
     },
     {
       "id": 220,
-      "input": "Write a function to replace maximum n occurrences of spaces, commas, or dots with a colon.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to replace maximum n occurrences of spaces, commas, or dots with a colon.\nYour code should pass this test case: assert replace_max_specialchar('Python language, Programming language.',2)==('Python:language: Programming language.')",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('Python language, Programming language.',2)==('Python:language: Programming language.')\n    assert candidate('a b c,d e f',3)==('a:b:c:d e f')\n    assert candidate('ram reshma,ram rahim',1)==('ram:reshma,ram rahim')\n",
       "language": "python"
     },
     {
       "id": 936,
-      "input": "Write a function to re-arrange the given tuples based on the given ordered list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to re-arrange the given tuples based on the given ordered list.\nYour code should pass this test case: assert re_arrange_tuples([(4, 3), (1, 9), (2, 10), (3, 2)],  [1, 4, 2, 3]) == [(1, 9), (4, 3), (2, 10), (3, 2)]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([(4, 3), (1, 9), (2, 10), (3, 2)],  [1, 4, 2, 3]) == [(1, 9), (4, 3), (2, 10), (3, 2)]\n    assert candidate([(5, 4), (2, 10), (3, 11), (4, 3)],  [3, 4, 2, 3]) == [(3, 11), (4, 3), (2, 10), (3, 11)]\n    assert candidate([(6, 3), (3, 8), (5, 7), (2, 4)],  [2, 5, 3, 6]) == [(2, 4), (5, 7), (3, 8), (6, 3)]\n",
       "language": "python"
     },
     {
       "id": 649,
-      "input": "Write a python function to calculate the sum of the numbers in a list between the indices of a specified range.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to calculate the sum of the numbers in a list between the indices of a specified range.\nYour code should pass this test case: assert sum_Range_list([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12],8,10) == 29",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12],8,10) == 29\n    assert candidate([1,2,3,4,5],1,2) == 5\n    assert candidate([1,0,1,2,5,6],4,5) == 11\n",
       "language": "python"
     },
     {
       "id": 489,
-      "input": "Write a python function to find the frequency of the largest value in a given array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the frequency of the largest value in a given array.\nYour code should pass this test case: assert frequency_Of_Largest(5,[1,2,3,4,4]) == 2",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(5,[1,2,3,4,4]) == 2\n    assert candidate(3,[5,6,5]) == 1\n    assert candidate(4,[2,7,7,7]) == 3\n",
       "language": "python"
     },
     {
       "id": 533,
-      "input": "Write a function to remove particular data type elements from the given tuple.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to remove particular data type elements from the given tuple.\nYour code should pass this test case: assert remove_datatype((4, 5, 4, 7.7, 1.2), int) == [7.7, 1.2]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((4, 5, 4, 7.7, 1.2), int) == [7.7, 1.2]\n    assert candidate((7, 8, 9, \"SR\"), str) == [7, 8, 9]\n    assert candidate((7, 1.1, 2, 2.2), float) == [7, 2]\n",
       "language": "python"
     },
     {
       "id": 862,
-      "input": "Write a function to find the occurrences of n most common words in a given text.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the occurrences of n most common words in a given text.\nYour code should pass this test case: assert n_common_words(\"python is a programming language\",1)==[('python', 1)]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"python is a programming language\",1)==[('python', 1)]\n    assert candidate(\"python is a programming language\",1)==[('python', 1)]\n    assert candidate(\"python is a programming language\",5)==[('python', 1),('is', 1), ('a', 1), ('programming', 1), ('language', 1)]\n",
       "language": "python"
     },
     {
       "id": 426,
-      "input": "Write a function to filter odd numbers using lambda function.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to filter odd numbers using lambda function.\nYour code should pass this test case: assert filter_oddnumbers([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])==[1,3,5,7,9]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])==[1,3,5,7,9]\n    assert candidate([10,20,45,67,84,93])==[45,67,93]\n    assert candidate([5,7,9,8,6,4,3])==[5,7,9,3]\n",
       "language": "python"
     },
     {
       "id": 828,
-      "input": "Write a function to count alphabets,digits and special charactes in a given string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to count alphabets,digits and special charactes in a given string.\nYour code should pass this test case: assert count_alpha_dig_spl(\"abc!@#123\")==(3,3,3)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"abc!@#123\")==(3,3,3)\n    assert candidate(\"dgsuy@#$%&1255\")==(5,4,5)\n    assert candidate(\"fjdsif627348#%$^&\")==(6,6,5)\n",
       "language": "python"
     },
     {
       "id": 690,
-      "input": "Write a function to multiply consecutive numbers of a given list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to multiply consecutive numbers of a given list.\nYour code should pass this test case: assert mul_consecutive_nums([1, 1, 3, 4, 4, 5, 6, 7])==[1, 3, 12, 16, 20, 30, 42]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 1, 3, 4, 4, 5, 6, 7])==[1, 3, 12, 16, 20, 30, 42]\n    assert candidate([4, 5, 8, 9, 6, 10])==[20, 40, 72, 54, 60]\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])==[2, 6, 12, 20, 30, 42, 56, 72, 90]\n",
       "language": "python"
     },
     {
       "id": 553,
-      "input": "Write a function to convert the given tuple to a floating-point number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to convert the given tuple to a floating-point number.\nYour code should pass this test case: assert tuple_to_float((4, 56)) == 4.56",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((4, 56)) == 4.56\n    assert candidate((7, 256)) == 7.256\n    assert candidate((8, 123)) == 8.123\n",
       "language": "python"
     },
     {
       "id": 545,
-      "input": "Write a python function to toggle only first and last bits of a given number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to toggle only first and last bits of a given number.\nYour code should pass this test case: assert toggle_F_and_L_bits(10) == 3",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10) == 3\n    assert candidate(15) == 6\n    assert candidate(20) == 5\n",
       "language": "python"
     },
     {
       "id": 812,
-      "input": "Write a function to abbreviate 'road' as 'rd.' in a given string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to abbreviate 'road' as 'rd.' in a given string.\nYour code should pass this test case: assert road_rd(\"ravipadu Road\")==('ravipadu Rd.')",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"ravipadu Road\")==('ravipadu Rd.')\n    assert candidate(\"palnadu Road\")==('palnadu Rd.')\n    assert candidate(\"eshwar enclave Road\")==('eshwar enclave Rd.')\n",
       "language": "python"
     },
     {
       "id": 288,
-      "input": "Write a function to count array elements having modular inverse under given prime number p equal to itself.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to count array elements having modular inverse under given prime number p equal to itself.\nYour code should pass this test case: assert modular_inverse([ 1, 6, 4, 5 ], 4, 7) == 2",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([ 1, 6, 4, 5 ], 4, 7) == 2\n    assert candidate([1, 3, 8, 12, 12], 5, 13) == 3\n    assert candidate([2, 3, 4, 5], 4, 6) == 1\n",
       "language": "python"
     },
     {
       "id": 49,
-      "input": "Write a function to extract every first or specified element from a given two-dimensional list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to extract every first or specified element from a given two-dimensional list.\nYour code should pass this test case: assert specified_element([[1, 2, 3, 2], [4, 5, 6, 2], [7, 1, 9, 5]],0)==[1, 4, 7]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[1, 2, 3, 2], [4, 5, 6, 2], [7, 1, 9, 5]],0)==[1, 4, 7]\n    assert candidate([[1, 2, 3, 2], [4, 5, 6, 2], [7, 1, 9, 5]],2)==[3, 6, 9]\n    assert candidate([[1, 2, 3, 2], [4, 5, 6, 2], [7, 1, 9, 5]],1)==[2,5,1]\n",
       "language": "python"
     },
     {
       "id": 588,
-      "input": "Write a python function to find the difference between largest and smallest value in a given array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the difference between largest and smallest value in a given array.\nYour code should pass this test case: assert big_diff([1,2,3,4]) == 3",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,3,4]) == 3\n    assert candidate([4,5,12]) == 8\n    assert candidate([9,2,3]) == 7\n",
       "language": "python"
     },
     {
       "id": 819,
-      "input": "Write a function to count the frequency of consecutive duplicate elements in a given list of numbers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to count the frequency of consecutive duplicate elements in a given list of numbers.\nYour code should pass this test case: assert count_duplic([1,2,2,2,4,4,4,5,5,5,5])==([1, 2, 4, 5], [1, 3, 3, 4])",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,2,2,4,4,4,5,5,5,5])==([1, 2, 4, 5], [1, 3, 3, 4])\n    assert candidate([2,2,3,1,2,6,7,9])==([2, 3, 1, 2, 6, 7, 9], [2, 1, 1, 1, 1, 1, 1])\n    assert candidate([2,1,5,6,8,3,4,9,10,11,8,12])==([2, 1, 5, 6, 8, 3, 4, 9, 10, 11, 8, 12], [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])\n",
       "language": "python"
     },
     {
       "id": 297,
-      "input": "Write a function to flatten a given nested list structure.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to flatten a given nested list structure.\nYour code should pass this test case: assert flatten_list([0, 10, [20, 30], 40, 50, [60, 70, 80], [90, 100, 110, 120]])==[0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([0, 10, [20, 30], 40, 50, [60, 70, 80], [90, 100, 110, 120]])==[0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120]\n    assert candidate([[10, 20], [40], [30, 56, 25], [10, 20], [33], [40]])==[10, 20, 40, 30, 56, 25, 10, 20, 33, 40]\n    assert candidate([[1,2,3], [4,5,6], [10,11,12], [7,8,9]])==[1, 2, 3, 4, 5, 6, 10, 11, 12, 7, 8, 9]\n",
       "language": "python"
     },
     {
       "id": 800,
-      "input": "Write a function to remove all whitespaces from a string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to remove all whitespaces from a string.\nYour code should pass this test case: assert remove_all_spaces('python  program')==('pythonprogram')",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('python  program')==('pythonprogram')\n    assert candidate('python   programming    language')==('pythonprogramminglanguage')\n    assert candidate('python                     program')==('pythonprogram')\n",
       "language": "python"
     },
     {
       "id": 780,
-      "input": "Write a function to find the combinations of sums with tuples in the given tuple list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the combinations of sums with tuples in the given tuple list.\nYour code should pass this test case: assert find_combinations([(2, 4), (6, 7), (5, 1), (6, 10)]) == [(8, 11), (7, 5), (8, 14), (11, 8), (12, 17), (11, 11)]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([(2, 4), (6, 7), (5, 1), (6, 10)]) == [(8, 11), (7, 5), (8, 14), (11, 8), (12, 17), (11, 11)]\n    assert candidate([(3, 5), (7, 8), (6, 2), (7, 11)]) == [(10, 13), (9, 7), (10, 16), (13, 10), (14, 19), (13, 13)]\n    assert candidate([(4, 6), (8, 9), (7, 3), (8, 12)]) == [(12, 15), (11, 9), (12, 18), (15, 12), (16, 21), (15, 15)]\n",
       "language": "python"
     },
     {
       "id": 207,
-      "input": "Write a function to count the longest repeating subsequences such that the two subsequences don\u2019t have same string characters at same positions.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to count the longest repeating subsequences such that the two subsequences don\u2019t have same string characters at same positions.\nYour code should pass this test case: assert find_longest_repeating_subseq(\"AABEBCDD\") == 3",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"AABEBCDD\") == 3\n    assert candidate(\"aabb\") == 2\n    assert candidate(\"aab\") == 1\n",
       "language": "python"
     },
     {
       "id": 290,
-      "input": "Write a function to find the list of lists with maximum length.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the list of lists with maximum length.\nYour code should pass this test case: assert max_length([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]])==(3, [13, 15, 17])",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]])==(3, [13, 15, 17])\n    assert candidate([[1], [5, 7], [10, 12, 14,15]])==(4, [10, 12, 14,15])\n    assert candidate([[5], [15,20,25]])==(3, [15,20,25])\n",
       "language": "python"
     },
     {
       "id": 325,
-      "input": "Write a python function to find the minimum number of squares whose sum is equal to a given number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the minimum number of squares whose sum is equal to a given number.\nYour code should pass this test case: assert get_Min_Squares(6) == 3",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(6) == 3\n    assert candidate(2) == 2\n    assert candidate(4) == 1\n",
       "language": "python"
     },
     {
       "id": 536,
-      "input": "Write a function to select the nth items of a list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to select the nth items of a list.\nYour code should pass this test case: assert nth_items([1, 2, 3, 4, 5, 6, 7, 8, 9],2)==[1, 3, 5, 7, 9] ",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9],2)==[1, 3, 5, 7, 9] \n    assert candidate([10,15,19,17,16,18],3)==[10,17] \n    assert candidate([14,16,19,15,17],4)==[14,17]\n",
       "language": "python"
     },
     {
       "id": 36,
-      "input": "Write a python function to find the nth digit in the proper fraction of two given numbers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the nth digit in the proper fraction of two given numbers.\nYour code should pass this test case: assert find_Nth_Digit(1,2,1) == 5",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(1,2,1) == 5\n    assert candidate(3,5,1) == 6\n    assert candidate(5,6,5) == 3\n",
       "language": "python"
     },
     {
       "id": 903,
-      "input": "Write a python function to count the total unset bits from 1 to n.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count the total unset bits from 1 to n.\nYour code should pass this test case: assert count_Unset_Bits(2) == 1",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(2) == 1\n    assert candidate(5) == 4\n    assert candidate(14) == 17\n",
       "language": "python"
     },
     {
       "id": 500,
-      "input": "Write a function to concatenate all elements of the given list into a string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to concatenate all elements of the given list into a string.\nYour code should pass this test case: assert concatenate_elements(['hello','there','have','a','rocky','day'] ) == '  hello there have a rocky day'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(['hello','there','have','a','rocky','day'] ) == '  hello there have a rocky day'\n    assert candidate([ 'Hi', 'there', 'How','are', 'you'] ) == '  Hi there How are you'\n    assert candidate([ 'Part', 'of', 'the','journey', 'is', 'end'] ) == '  Part of the journey is end'\n",
       "language": "python"
     },
     {
       "id": 430,
-      "input": "Write a function to find the directrix of a parabola.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the directrix of a parabola.\nYour code should pass this test case: assert parabola_directrix(5,3,2)==-198",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(5,3,2)==-198\n    assert candidate(9,8,4)==-2336\n    assert candidate(2,4,6)==-130\n",
       "language": "python"
     },
     {
       "id": 830,
-      "input": "Write a function to round up a number to specific digits.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to round up a number to specific digits.\nYour code should pass this test case: assert round_up(123.01247,0)==124",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(123.01247,0)==124\n    assert candidate(123.01247,1)==123.1\n    assert candidate(123.01247,2)==123.02\n",
       "language": "python"
     },
     {
       "id": 729,
-      "input": "Write a function to add two lists using map and lambda function.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to add two lists using map and lambda function.\nYour code should pass this test case: assert add_list([1, 2, 3],[4,5,6])==[5, 7, 9]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 2, 3],[4,5,6])==[5, 7, 9]\n    assert candidate([1,2],[3,4])==[4,6]\n    assert candidate([10,20],[50,70])==[60,90]\n",
       "language": "python"
     },
     {
       "id": 592,
-      "input": "Write a python function to find sum of product of binomial co-efficients.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find sum of product of binomial co-efficients.\nYour code should pass this test case: assert sum_Of_product(3) == 15",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(3) == 15\n    assert candidate(4) == 56\n    assert candidate(1) == 1\n",
       "language": "python"
     },
     {
       "id": 222,
-      "input": "Write a function to check if all the elements in tuple have same data type or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check if all the elements in tuple have same data type or not.\nYour code should pass this test case: assert check_type((5, 6, 7, 3, 5, 6) ) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((5, 6, 7, 3, 5, 6) ) == True\n    assert candidate((1, 2, \"4\") ) == False\n    assert candidate((3, 2, 1, 4, 5) ) == True\n",
       "language": "python"
     },
     {
       "id": 231,
-      "input": "Write a function to find the maximum sum in the given right triangle of numbers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the maximum sum in the given right triangle of numbers.\nYour code should pass this test case: assert max_sum([[1], [2,1], [3,3,2]], 3) == 6",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[1], [2,1], [3,3,2]], 3) == 6\n    assert candidate([[1], [1, 2], [4, 1, 12]], 3) == 15 \n    assert candidate([[2], [3,2], [13,23,12]], 3) == 28\n",
       "language": "python"
     },
     {
       "id": 99,
-      "input": "Write a function to convert the given decimal number to its binary equivalent.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to convert the given decimal number to its binary equivalent.\nYour code should pass this test case: assert decimal_to_binary(8) == '1000'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(8) == '1000'\n    assert candidate(18) == '10010'\n    assert candidate(7) == '111' \n",
       "language": "python"
     },
     {
       "id": 911,
-      "input": "Write a function to compute maximum product of three numbers of a given array of integers using heap queue algorithm.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to compute maximum product of three numbers of a given array of integers using heap queue algorithm.\nYour code should pass this test case: assert maximum_product( [12, 74, 9, 50, 61, 41])==225700",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate( [12, 74, 9, 50, 61, 41])==225700\n    assert candidate([25, 35, 22, 85, 14, 65, 75, 25, 58])==414375\n    assert candidate([18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1])==2520\n",
       "language": "python"
     },
     {
       "id": 589,
-      "input": "Write a function to find perfect squares between two given numbers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find perfect squares between two given numbers.\nYour code should pass this test case: assert perfect_squares(1,30)==[1, 4, 9, 16, 25]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(1,30)==[1, 4, 9, 16, 25]\n    assert candidate(50,100)==[64, 81, 100]\n    assert candidate(100,200)==[100, 121, 144, 169, 196]\n",
       "language": "python"
     },
     {
       "id": 226,
-      "input": "Write a python function to remove the characters which have odd index values of a given string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to remove the characters which have odd index values of a given string.\nYour code should pass this test case: assert odd_values_string('abcdef') == 'ace'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('abcdef') == 'ace'\n    assert candidate('python') == 'pto'\n    assert candidate('data') == 'dt'\n",
       "language": "python"
     },
     {
       "id": 803,
-      "input": "Write a python function to check whether the given number is a perfect square or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether the given number is a perfect square or not.\nYour code should pass this test case: assert is_Perfect_Square(10) == False",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10) == False\n    assert candidate(36) == True\n    assert candidate(14) == False\n",
       "language": "python"
     },
     {
       "id": 700,
-      "input": "Write a function to count the number of elements in a list which are within a specific range.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to count the number of elements in a list which are within a specific range.\nYour code should pass this test case: assert count_range_in_list([10,20,30,40,40,40,70,80,99],40,100)==6",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([10,20,30,40,40,40,70,80,99],40,100)==6\n    assert candidate(['a','b','c','d','e','f'],'a','e')==5\n    assert candidate([7,8,9,15,17,19,45],15,20)==3\n",
       "language": "python"
     },
     {
       "id": 646,
-      "input": "Write a python function to count number of cubes of size k in a cube of size n.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count number of cubes of size k in a cube of size n.\nYour code should pass this test case: assert No_of_cubes(2,1) == 8",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(2,1) == 8\n    assert candidate(5,2) == 64\n    assert candidate(1,1) == 1\n",
       "language": "python"
     },
     {
       "id": 306,
-      "input": "Write a function to find the maximum sum of increasing subsequence from prefix till ith index and also including a given kth element which is after i, i.e., k > i .",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the maximum sum of increasing subsequence from prefix till ith index and also including a given kth element which is after i, i.e., k > i .\nYour code should pass this test case: assert max_sum_increasing_subseq([1, 101, 2, 3, 100, 4, 5 ], 7, 4, 6) == 11",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 101, 2, 3, 100, 4, 5 ], 7, 4, 6) == 11\n    assert candidate([1, 101, 2, 3, 100, 4, 5 ], 7, 2, 5) == 7\n    assert candidate([11, 15, 19, 21, 26, 28, 31], 7, 2, 4) == 71\n",
       "language": "python"
     },
     {
       "id": 146,
-      "input": "Write a function to find the ascii value of total characters in a string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the ascii value of total characters in a string.\nYour code should pass this test case: assert ascii_value_string(\"python\")==112",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"python\")==112\n    assert candidate(\"Program\")==80\n    assert candidate(\"Language\")==76\n",
       "language": "python"
     },
     {
       "id": 384,
-      "input": "Write a python function to find the frequency of the smallest value in a given array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the frequency of the smallest value in a given array.\nYour code should pass this test case: assert frequency_Of_Smallest(5,[1,2,3,4,3]) == 1",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(5,[1,2,3,4,3]) == 1\n    assert candidate(7,[3,1,2,5,6,2,3]) == 1\n    assert candidate(7,[3,3,6,3,7,4,9]) == 3\n",
       "language": "python"
     },
     {
       "id": 692,
-      "input": "Write a python function to find the last two digits in factorial of a given number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the last two digits in factorial of a given number.\nYour code should pass this test case: assert last_Two_Digits(7) == 40",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(7) == 40\n    assert candidate(5) == 20\n    assert candidate(2) == 2\n",
       "language": "python"
     },
     {
       "id": 291,
-      "input": "Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find out the number of ways of painting the fence such that at most 2 adjacent posts have the same color for the given fence with n posts and k colors.\nYour code should pass this test case: assert count_no_of_ways(2, 4) == 16",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(2, 4) == 16\n    assert candidate(3, 2) == 6\n    assert candidate(4, 4) == 228\n",
       "language": "python"
     },
     {
       "id": 925,
-      "input": "Write a python function to calculate the product of all the numbers of a given tuple.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to calculate the product of all the numbers of a given tuple.\nYour code should pass this test case: assert mutiple_tuple((4, 3, 2, 2, -1, 18)) == -864",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((4, 3, 2, 2, -1, 18)) == -864\n    assert candidate((1,2,3)) == 6\n    assert candidate((-2,-4,-6)) == -48\n",
       "language": "python"
     },
     {
       "id": 627,
-      "input": "Write a python function to find the smallest missing number from the given array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the smallest missing number from the given array.\nYour code should pass this test case: assert find_First_Missing([0,1,2,3],0,3) == 4",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([0,1,2,3],0,3) == 4\n    assert candidate([0,1,2,6,9],0,4) == 3\n    assert candidate([2,3,5,8,9],0,4) == 0\n",
       "language": "python"
     },
     {
       "id": 148,
-      "input": "Write a function to divide a number into two parts such that the sum of digits is maximum.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to divide a number into two parts such that the sum of digits is maximum.\nYour code should pass this test case: assert sum_digits_twoparts(35)==17",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(35)==17\n    assert candidate(7)==7\n    assert candidate(100)==19\n",
       "language": "python"
     },
     {
       "id": 436,
-      "input": "Write a python function to print negative numbers in a list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to print negative numbers in a list.\nYour code should pass this test case: assert neg_nos([-1,4,5,-6]) == -1,-6",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([-1,4,5,-6]) == -1,-6\n    assert candidate([-1,-2,3,4]) == -1,-2\n    assert candidate([-7,-6,8,9]) == -7,-6\n",
       "language": "python"
     },
     {
       "id": 823,
-      "input": "Write a function to check if the given string starts with a substring using regex.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check if the given string starts with a substring using regex.\nYour code should pass this test case: assert check_substring(\"dreams for dreams makes life fun\", \"makes\") == 'string doesnt start with the given substring'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"dreams for dreams makes life fun\", \"makes\") == 'string doesnt start with the given substring'\n    assert candidate(\"Hi there how are you Hi alex\", \"Hi\") == 'string starts with the given substring'\n    assert candidate(\"Its been a long day\", \"been\") == 'string doesnt start with the given substring'\n",
       "language": "python"
     },
     {
       "id": 31,
-      "input": "Write a function to find the top k integers that occur most frequently from given lists of sorted and distinct integers using heap queue algorithm.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the top k integers that occur most frequently from given lists of sorted and distinct integers using heap queue algorithm.\nYour code should pass this test case: assert func([[1, 2, 6], [1, 3, 4, 5, 7, 8], [1, 3, 5, 6, 8, 9], [2, 5, 7, 11], [1, 4, 7, 8, 12]],3)==[5, 7, 1]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[1, 2, 6], [1, 3, 4, 5, 7, 8], [1, 3, 5, 6, 8, 9], [2, 5, 7, 11], [1, 4, 7, 8, 12]],3)==[5, 7, 1]\n    assert candidate([[1, 2, 6], [1, 3, 4, 5, 7, 8], [1, 3, 5, 6, 8, 9], [2, 5, 7, 11], [1, 4, 7, 8, 12]],1)==[1]\n    assert candidate([[1, 2, 6], [1, 3, 4, 5, 7, 8], [1, 3, 5, 6, 8, 9], [2, 5, 7, 11], [1, 4, 7, 8, 12]],5)==[6, 5, 7, 8, 1]\n",
       "language": "python"
     },
     {
       "id": 804,
-      "input": "Write a python function to check whether the product of numbers is even or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether the product of numbers is even or not.\nYour code should pass this test case: assert is_Product_Even([1,2,3],3) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,3],3) == True\n    assert candidate([1,2,1,4],4) == True\n    assert candidate([1,1],2) == False\n",
       "language": "python"
     },
     {
       "id": 899,
-      "input": "Write a python function to check whether an array can be sorted or not by picking only the corner elements.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether an array can be sorted or not by picking only the corner elements.\nYour code should pass this test case: assert check([3,2,1,2,3,4],6) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([3,2,1,2,3,4],6) == True\n    assert candidate([2,1,4,5,1],5) == True\n    assert candidate([1,2,2,1,2,3],6) == True\n",
       "language": "python"
     },
     {
       "id": 329,
-      "input": "Write a python function to count negative numbers in a list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count negative numbers in a list.\nYour code should pass this test case: assert neg_count([-1,-2,3,-4,-5]) == 4",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([-1,-2,3,-4,-5]) == 4\n    assert candidate([1,2,3]) == 0\n    assert candidate([1,2,-3,-10,20]) == 2\n",
       "language": "python"
     },
     {
       "id": 38,
-      "input": "Write a function to find the division of first even and odd number of a given list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the division of first even and odd number of a given list.\nYour code should pass this test case: assert div_even_odd([1,3,5,7,4,1,6,8])==4",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,3,5,7,4,1,6,8])==4\n    assert candidate([1,2,3,4,5,6,7,8,9,10])==2\n    assert candidate([1,5,7,9,10])==10\n",
       "language": "python"
     },
     {
       "id": 171,
-      "input": "Write a function to find the perimeter of a pentagon.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the perimeter of a pentagon.\nYour code should pass this test case: assert perimeter_pentagon(5)==25",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(5)==25\n    assert candidate(10)==50\n    assert candidate(15)==75\n",
       "language": "python"
     },
     {
       "id": 313,
-      "input": "Write a python function to print positive numbers in a list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to print positive numbers in a list.\nYour code should pass this test case: assert pos_nos([-1,-2,1,2]) == 1,2",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([-1,-2,1,2]) == 1,2\n    assert candidate([3,4,-5]) == 3,4\n    assert candidate([-2,-3,1]) == 1\n",
       "language": "python"
     },
     {
       "id": 459,
-      "input": "Write a function to remove uppercase substrings from a given string by using regex.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to remove uppercase substrings from a given string by using regex.\nYour code should pass this test case: assert remove_uppercase('cAstyoUrFavoRitETVshoWs') == 'cstyoravoitshos'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('cAstyoUrFavoRitETVshoWs') == 'cstyoravoitshos'\n    assert candidate('wAtchTheinTernEtrAdIo') == 'wtchheinerntrdo'\n    assert candidate('VoicESeaRchAndreComMendaTionS') == 'oiceachndreomendaion'\n",
       "language": "python"
     },
     {
       "id": 863,
-      "input": "Write a function to find the length of the longest sub-sequence such that elements in the subsequences are consecutive integers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the length of the longest sub-sequence such that elements in the subsequences are consecutive integers.\nYour code should pass this test case: assert find_longest_conseq_subseq([1, 2, 2, 3], 4) == 3",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 2, 2, 3], 4) == 3\n    assert candidate([1, 9, 3, 10, 4, 20, 2], 7) == 4\n    assert candidate([36, 41, 56, 35, 44, 33, 34, 92, 43, 32, 42], 11) == 5\n",
       "language": "python"
     },
     {
       "id": 77,
-      "input": "Write a python function to find the difference between sum of even and odd digits.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the difference between sum of even and odd digits.\nYour code should pass this test case: assert is_Diff (12345) == False",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(12345) == False\n    assert candidate(1212112) == True\n    assert candidate(1212) == False\n",
       "language": "python"
     },
     {
       "id": 268,
-      "input": "Write a function to find the n'th star number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the n'th star number.\nYour code should pass this test case: assert find_star_num(3) == 37",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(3) == 37\n    assert candidate(4) == 73\n    assert candidate(5) == 121\n",
       "language": "python"
     },
     {
       "id": 25,
-      "input": "Write a python function to find the product of non-repeated elements in a given array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the product of non-repeated elements in a given array.\nYour code should pass this test case: assert find_Product([1,1,2,3],4) == 6",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,1,2,3],4) == 6\n    assert candidate([1,2,3,1,1],5) == 6\n    assert candidate([1,1,4,5,6],5) == 120\n    assert candidate([1,1,4,5,6,5,7,1,1,3,4],11) == 2520\n",
       "language": "python"
     },
     {
       "id": 232,
-      "input": "Write a function to get the n largest items from a dataset.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to get the n largest items from a dataset.\nYour code should pass this test case: assert larg_nnum([10, 20, 50, 70, 90, 20, 50, 40, 60, 80, 100],2)==[100,90]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([10, 20, 50, 70, 90, 20, 50, 40, 60, 80, 100],2)==[100,90]\n    assert candidate([10, 20, 50, 70, 90, 20, 50, 40, 60, 80, 100],5)==[100,90,80,70,60]\n    assert candidate([10, 20, 50, 70, 90, 20, 50, 40, 60, 80, 100],3)==[100,90,80]\n",
       "language": "python"
     },
     {
       "id": 841,
-      "input": "Write a function to count the number of inversions in the given array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to count the number of inversions in the given array.\nYour code should pass this test case: assert get_inv_count([1, 20, 6, 4, 5], 5) == 5",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 20, 6, 4, 5], 5) == 5\n    assert candidate([8, 4, 2, 1], 4) == 6\n    assert candidate([3, 1, 2], 3) == 2\n",
       "language": "python"
     },
     {
       "id": 496,
-      "input": "Write a function to find the smallest integers from a given list of numbers using heap queue algorithm.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the smallest integers from a given list of numbers using heap queue algorithm.\nYour code should pass this test case: assert heap_queue_smallest( [25, 35, 22, 85, 14, 65, 75, 25, 58],3)==[14, 22, 25] ",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate( [25, 35, 22, 85, 14, 65, 75, 25, 58],3)==[14, 22, 25] \n    assert candidate( [25, 35, 22, 85, 14, 65, 75, 25, 58],2)==[14, 22]\n    assert candidate( [25, 35, 22, 85, 14, 65, 75, 22, 58],5)==[14, 22, 22, 25, 35]\n",
       "language": "python"
     },
     {
       "id": 40,
-      "input": "Write a function to find frequency of the elements in a given list of lists using collections module.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find frequency of the elements in a given list of lists using collections module.\nYour code should pass this test case: assert freq_element([[1, 2, 3, 2], [4, 5, 6, 2], [7, 1, 9, 5]])==({2: 3, 1: 2, 5: 2, 3: 1, 4: 1, 6: 1, 7: 1, 9: 1})",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[1, 2, 3, 2], [4, 5, 6, 2], [7, 1, 9, 5]])==({2: 3, 1: 2, 5: 2, 3: 1, 4: 1, 6: 1, 7: 1, 9: 1})\n    assert candidate([[1,2,3,4],[5,6,7,8],[9,10,11,12]])==({1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1, 7: 1, 8: 1, 9: 1, 10: 1, 11: 1, 12: 1})\n    assert candidate([[15,20,30,40],[80,90,100,110],[30,30,80,90]])==({30: 3, 80: 2, 90: 2, 15: 1, 20: 1, 40: 1, 100: 1, 110: 1})\n",
       "language": "python"
     },
     {
       "id": 228,
-      "input": "Write a python function to check whether all the bits are unset in the given range or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether all the bits are unset in the given range or not.\nYour code should pass this test case: assert all_Bits_Set_In_The_Given_Range(4,1,2) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(4,1,2) == True\n    assert candidate(17,2,4) == True\n    assert candidate(39,4,6) == False\n",
       "language": "python"
     },
     {
       "id": 250,
-      "input": "Write a python function to count the occcurences of an element in a tuple.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count the occcurences of an element in a tuple.\nYour code should pass this test case: assert count_X((10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2),4) == 0",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2),4) == 0\n    assert candidate((10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2),10) == 3\n    assert candidate((10, 8, 5, 2, 10, 15, 10, 8, 5, 8, 8, 2),8) == 4\n",
       "language": "python"
     },
     {
       "id": 614,
-      "input": "Write a function to find the cumulative sum of all the values that are present in the given tuple list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the cumulative sum of all the values that are present in the given tuple list.\nYour code should pass this test case: assert cummulative_sum([(1, 3), (5, 6, 7), (2, 6)]) == 30",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([(1, 3), (5, 6, 7), (2, 6)]) == 30\n    assert candidate([(2, 4), (6, 7, 8), (3, 7)]) == 37\n    assert candidate([(3, 5), (7, 8, 9), (4, 8)]) == 44\n",
       "language": "python"
     },
     {
       "id": 135,
-      "input": "Write a function to find the nth hexagonal number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the nth hexagonal number.\nYour code should pass this test case: assert hexagonal_num(10) == 190",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10) == 190\n    assert candidate(5) == 45\n    assert candidate(7) == 91\n",
       "language": "python"
     },
     {
       "id": 542,
-      "input": "Write a function to replace all occurrences of spaces, commas, or dots with a colon in the given string by using regex.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to replace all occurrences of spaces, commas, or dots with a colon in the given string by using regex.\nYour code should pass this test case: assert fill_spaces('Boult Curve Wireless Neckband') == 'Boult:Curve:Wireless:Neckband'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('Boult Curve Wireless Neckband') == 'Boult:Curve:Wireless:Neckband'\n    assert candidate('Stereo Sound Sweatproof') == 'Stereo:Sound:Sweatproof'\n    assert candidate('Probass Curve Audio') == 'Probass:Curve:Audio'\n",
       "language": "python"
     },
     {
       "id": 670,
-      "input": "Write a python function to check whether a sequence of numbers has a decreasing trend or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether a sequence of numbers has a decreasing trend or not.\nYour code should pass this test case: assert decreasing_trend([-4,-3,-2,-1]) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([-4,-3,-2,-1]) == True\n    assert candidate([1,2,3]) == True\n    assert candidate([3,2,1]) == False\n",
       "language": "python"
     },
     {
       "id": 621,
-      "input": "Write a function to increment the numeric values in the given strings by k.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to increment the numeric values in the given strings by k.\nYour code should pass this test case: assert increment_numerics([\"MSM\", \"234\", \"is\", \"98\", \"123\", \"best\", \"4\"] , 6) == ['MSM', '240', 'is', '104', '129', 'best', '10']",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([\"MSM\", \"234\", \"is\", \"98\", \"123\", \"best\", \"4\"] , 6) == ['MSM', '240', 'is', '104', '129', 'best', '10']\n    assert candidate([\"Dart\", \"356\", \"is\", \"88\", \"169\", \"Super\", \"6\"] , 12) == ['Dart', '368', 'is', '100', '181', 'Super', '18']\n    assert candidate([\"Flutter\", \"451\", \"is\", \"44\", \"96\", \"Magnificent\", \"12\"] , 33) == ['Flutter', '484', 'is', '77', '129', 'Magnificent', '45']\n",
       "language": "python"
     },
     {
       "id": 929,
-      "input": "Write a function to count repeated items of a tuple.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to count repeated items of a tuple.\nYour code should pass this test case: assert count_tuplex((2, 4, 5, 6, 2, 3, 4, 4, 7),4)==3",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((2, 4, 5, 6, 2, 3, 4, 4, 7),4)==3\n    assert candidate((2, 4, 5, 6, 2, 3, 4, 4, 7),2)==2\n    assert candidate((2, 4, 7, 7, 7, 3, 4, 4, 7),7)==4\n",
       "language": "python"
     },
     {
       "id": 555,
-      "input": "Write a python function to find the difference between sum of cubes of first n natural numbers and the sum of first n natural numbers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the difference between sum of cubes of first n natural numbers and the sum of first n natural numbers.\nYour code should pass this test case: assert difference(3) == 30",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(3) == 30\n    assert candidate(5) == 210\n    assert candidate(2) == 6\n",
       "language": "python"
     },
     {
       "id": 165,
-      "input": "Write a python function to count characters at same position in a given string (lower and uppercase characters) as in english alphabet.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count characters at same position in a given string (lower and uppercase characters) as in english alphabet.\nYour code should pass this test case: assert count_char_position(\"xbcefg\") == 2",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"xbcefg\") == 2\n    assert candidate(\"ABcED\") == 3\n    assert candidate(\"AbgdeF\") == 5\n",
       "language": "python"
     },
     {
       "id": 953,
-      "input": "Write a python function to find the minimun number of subsets with distinct elements.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the minimun number of subsets with distinct elements.\nYour code should pass this test case: assert subset([1, 2, 3, 4],4) == 1",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 2, 3, 4],4) == 1\n    assert candidate([5, 6, 9, 3, 4, 3, 4],7) == 2\n    assert candidate([1, 2, 3 ],3) == 1\n",
       "language": "python"
     },
     {
       "id": 713,
-      "input": "Write a function to check if the given tuple contains all valid values or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check if the given tuple contains all valid values or not.\nYour code should pass this test case: assert check_valid((True, True, True, True) ) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((True, True, True, True) ) == True\n    assert candidate((True, False, True, True) ) == False\n    assert candidate((True, True, True, True) ) == True\n",
       "language": "python"
     },
     {
       "id": 133,
-      "input": "Write a function to calculate the sum of the negative numbers of a given list of numbers using lambda function.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to calculate the sum of the negative numbers of a given list of numbers using lambda function.\nYour code should pass this test case: assert sum_negativenum([2, 4, -6, -9, 11, -12, 14, -5, 17])==-32",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([2, 4, -6, -9, 11, -12, 14, -5, 17])==-32\n    assert candidate([10,15,-14,13,-18,12,-20])==-52\n    assert candidate([19, -65, 57, 39, 152,-639, 121, 44, 90, -190])==-894\n",
       "language": "python"
     },
     {
       "id": 495,
-      "input": "Write a function to remove lowercase substrings from a given string by using regex.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to remove lowercase substrings from a given string by using regex.\nYour code should pass this test case: assert remove_lowercase('KDeoALOklOOHserfLoAJSIskdsf') == 'KDALOOOHLAJSI'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('KDeoALOklOOHserfLoAJSIskdsf') == 'KDALOOOHLAJSI'\n    assert candidate('ProducTnamEstreAmIngMediAplAYer') == 'PTEAIMAAY'\n    assert candidate('maNufacTuredbYSheZenTechNolOGIes') == 'NTYSZTNOGI'\n",
       "language": "python"
     },
     {
       "id": 416,
-      "input": "Write a function to find the maximum sum we can make by dividing number in three parts recursively and summing them up together for the given number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the maximum sum we can make by dividing number in three parts recursively and summing them up together for the given number.\nYour code should pass this test case: assert breakSum(12) == 13",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(12) == 13\n    assert candidate(24) == 27\n    assert candidate(23) == 23\n",
       "language": "python"
     },
     {
       "id": 689,
-      "input": "## write a function to find the minimum number of jumps to reach the end of the array for the given array of integers where each element represents the max number of steps that can be made forward from that element. > indented block > indented block",
+      "input": "You are an expert Python programmer, and here is your task: ## write a function to find the minimum number of jumps to reach the end of the array for the given array of integers where each element represents the max number of steps that can be made forward from that element. > indented block > indented block\nYour code should pass this test case: assert min_jumps([1, 3, 6, 1, 0, 9], 6) == 3",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 3, 6, 1, 0, 9], 6) == 3\n    assert candidate([1, 3, 5, 8, 9, 2, 6, 7, 6, 8, 9], 11) == 3\n    assert candidate([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], 11) == 10\n",
       "language": "python"
     },
     {
       "id": 704,
-      "input": "Write a function to calculate the harmonic sum of n-1.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to calculate the harmonic sum of n-1.\nYour code should pass this test case: assert harmonic_sum(10)==2.9289682539682538",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10)==2.9289682539682538\n    assert candidate(4)==2.083333333333333\n    assert candidate(7)==2.5928571428571425 \n",
       "language": "python"
     },
     {
       "id": 768,
-      "input": "Write a python function to check for odd parity of a given number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check for odd parity of a given number.\nYour code should pass this test case: assert check_Odd_Parity(13) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(13) == True\n    assert candidate(21) == True\n    assert candidate(18) == False\n",
       "language": "python"
     },
     {
       "id": 415,
-      "input": "Write a python function to find a pair with highest product from a given array of integers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find a pair with highest product from a given array of integers.\nYour code should pass this test case: assert max_Product([1,2,3,4,7,0,8,4]) == (7,8)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,3,4,7,0,8,4]) == (7,8)\n    assert candidate([0,-1,-2,-4,5,0,-6]) == (-4,-6)\n    assert candidate([1,2,3]) == (2,3)\n",
       "language": "python"
     },
     {
       "id": 898,
-      "input": "Write a function to extract specified number of elements from a given list, which follow each other continuously.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to extract specified number of elements from a given list, which follow each other continuously.\nYour code should pass this test case: assert extract_elements([1, 1, 3, 4, 4, 5, 6, 7],2)==[1, 4]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 1, 3, 4, 4, 5, 6, 7],2)==[1, 4]\n    assert candidate([0, 1, 2, 3, 4, 4, 4, 4, 5, 7],4)==[4]\n    assert candidate([0,0,0,0,0],5)==[0]\n",
       "language": "python"
     },
     {
       "id": 928,
-      "input": "Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format.\nYour code should pass this test case: assert change_date_format('2026-01-02')=='02-01-2026'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('2026-01-02')=='02-01-2026'\n    assert candidate('2021-01-04')=='04-01-2021'\n    assert candidate('2030-06-06')=='06-06-2030'\n",
       "language": "python"
     },
     {
       "id": 714,
-      "input": "Write a python function to count the number of distinct power of prime factor of given number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count the number of distinct power of prime factor of given number.\nYour code should pass this test case: assert count_Fac(24) == 3",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(24) == 3\n    assert candidate(12) == 2\n    assert candidate(4) == 1\n",
       "language": "python"
     },
     {
       "id": 528,
-      "input": "Write a function to find the list of lists with minimum length.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the list of lists with minimum length.\nYour code should pass this test case: assert min_length([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]])==(1, [0])",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]])==(1, [0])\n    assert candidate([[1], [5, 7], [10, 12, 14,15]])==(1, [1])\n    assert candidate([[5], [15,20,25]])==(1, [5])\n",
       "language": "python"
     },
     {
       "id": 728,
-      "input": "Write a function to sum elements in two lists.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to sum elements in two lists.\nYour code should pass this test case: assert sum_list([10,20,30],[15,25,35])==[25,45,65]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([10,20,30],[15,25,35])==[25,45,65]\n    assert candidate([1,2,3],[5,6,7])==[6,8,10]\n    assert candidate([15,20,30],[15,45,75])==[30,65,105]\n",
       "language": "python"
     },
     {
       "id": 884,
-      "input": "Write a python function to check whether all the bits are within a given range or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether all the bits are within a given range or not.\nYour code should pass this test case: assert all_Bits_Set_In_The_Given_Range(10,2,1) == True ",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10,2,1) == True \n    assert candidate(5,2,4) == False\n    assert candidate(22,2,3) == True \n",
       "language": "python"
     },
     {
       "id": 30,
-      "input": "Write a python function to count all the substrings starting and ending with same characters.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count all the substrings starting and ending with same characters.\nYour code should pass this test case: assert count_Substring_With_Equal_Ends(\"abc\") == 3",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"abc\") == 3\n    assert candidate(\"abcda\") == 6\n    assert candidate(\"ab\") == 2\n",
       "language": "python"
     },
     {
       "id": 21,
-      "input": "Write a function to find m number of multiples of n.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find m number of multiples of n.\nYour code should pass this test case: assert multiples_of_num(4,3)== [3,6,9,12]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(4,3)== [3,6,9,12]\n    assert candidate(2,5)== [5,10]\n    assert candidate(9,2)== [2,4,6,8,10,12,14,16,18]\n",
       "language": "python"
     },
     {
       "id": 877,
-      "input": "Write a python function to sort the given string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to sort the given string.\nYour code should pass this test case: assert sort_String(\"cba\") == \"abc\"",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"cba\") == \"abc\"\n    assert candidate(\"data\") == \"aadt\"\n    assert candidate(\"zxy\") == \"xyz\"\n",
       "language": "python"
     },
     {
       "id": 173,
-      "input": "Write a function to remove everything except alphanumeric characters from a string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to remove everything except alphanumeric characters from a string.\nYour code should pass this test case: assert remove_splchar('python  @#&^%$*program123')==('pythonprogram123')",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('python  @#&^%$*program123')==('pythonprogram123')\n    assert candidate('python %^$@!^&*()  programming24%$^^()    language')==('pythonprogramming24language')\n    assert candidate('python   ^%&^()(+_)(_^&67)                  program')==('python67program')\n",
       "language": "python"
     }
@@ -2928,2923 +2928,2923 @@
   "test": [
     {
       "id": 872,
-      "input": "Write a function to check if a nested list is a subset of another nested list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check if a nested list is a subset of another nested list.\nYour code should pass this test case: assert check_subset([[1, 3], [5, 7], [9, 11], [13, 15, 17]] ,[[1, 3],[13,15,17]])==True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[1, 3], [5, 7], [9, 11], [13, 15, 17]] ,[[1, 3],[13,15,17]])==True\n    assert candidate([[1, 2], [2, 3], [3, 4], [5, 6]],[[3, 4], [5, 6]])==True\n    assert candidate([[[1, 2], [2, 3]], [[3, 4], [5, 7]]],[[[3, 4], [5, 6]]])==False\n",
       "language": "python"
     },
     {
       "id": 114,
-      "input": "Write a function to assign frequency to each tuple in the given tuple list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to assign frequency to each tuple in the given tuple list.\nYour code should pass this test case: assert assign_freq([(6, 5, 8), (2, 7), (6, 5, 8), (6, 5, 8), (9, ), (2, 7)] ) == '[(6, 5, 8, 3), (2, 7, 2), (9, 1)]'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([(6, 5, 8), (2, 7), (6, 5, 8), (6, 5, 8), (9, ), (2, 7)] ) == '[(6, 5, 8, 3), (2, 7, 2), (9, 1)]'\n    assert candidate([(4, 2, 4), (7, 1), (4, 8), (4, 2, 4), (9, 2), (7, 1)] ) == '[(4, 2, 4, 2), (7, 1, 2), (4, 8, 1), (9, 2, 1)]'\n    assert candidate([(11, 13, 10), (17, 21), (4, 2, 3), (17, 21), (9, 2), (4, 2, 3)] ) == '[(11, 13, 10, 1), (17, 21, 2), (4, 2, 3, 2), (9, 2, 1)]'\n",
       "language": "python"
     },
     {
       "id": 893,
-      "input": "Write a python function to get the last element of each sublist.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to get the last element of each sublist.\nYour code should pass this test case: assert Extract([[1, 2, 3], [4, 5], [6, 7, 8, 9]]) == [3, 5, 9]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[1, 2, 3], [4, 5], [6, 7, 8, 9]]) == [3, 5, 9]\n    assert candidate([['x', 'y', 'z'], ['m'], ['a', 'b'], ['u', 'v']]) == ['z', 'm', 'b', 'v']\n    assert candidate([[1, 2, 3], [4, 5]]) == [3, 5]\n",
       "language": "python"
     },
     {
       "id": 818,
-      "input": "Write a python function to count lower case letters in a given string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count lower case letters in a given string.\nYour code should pass this test case: assert lower_ctr('abc') == 3",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('abc') == 3\n    assert candidate('string') == 6\n    assert candidate('Python') == 5\n",
       "language": "python"
     },
     {
       "id": 617,
-      "input": "Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check for the number of jumps required of given length to reach a point of form (d, 0) from origin in a 2d plane.\nYour code should pass this test case: assert min_Jumps(3,4,11)==3.5",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(3,4,11)==3.5\n    assert candidate(3,4,0)==0\n    assert candidate(11,14,11)==1\n",
       "language": "python"
     },
     {
       "id": 603,
-      "input": "Write a function to get a lucid number smaller than or equal to n.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to get a lucid number smaller than or equal to n.\nYour code should pass this test case: assert get_ludic(10) == [1, 2, 3, 5, 7]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10) == [1, 2, 3, 5, 7]\n    assert candidate(25) == [1, 2, 3, 5, 7, 11, 13, 17, 23, 25]\n    assert candidate(45) == [1, 2, 3, 5, 7, 11, 13, 17, 23, 25, 29, 37, 41, 43]\n",
       "language": "python"
     },
     {
       "id": 736,
-      "input": "Write a function to locate the left insertion point for a specified value in sorted order.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to locate the left insertion point for a specified value in sorted order.\nYour code should pass this test case: assert left_insertion([1,2,4,5],6)==4",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,4,5],6)==4\n    assert candidate([1,2,4,5],3)==2\n    assert candidate([1,2,4,5],7)==4\n",
       "language": "python"
     },
     {
       "id": 76,
-      "input": "Write a python function to count the number of squares in a rectangle.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count the number of squares in a rectangle.\nYour code should pass this test case: assert count_Squares(4,3) == 20",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(4,3) == 20\n    assert candidate(2,2) == 5\n    assert candidate(1,1) == 1\n",
       "language": "python"
     },
     {
       "id": 967,
-      "input": "Write a python function to accept the strings which contains all vowels.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to accept the strings which contains all vowels.\nYour code should pass this test case: assert check(\"SEEquoiaL\") == 'accepted'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"SEEquoiaL\") == 'accepted'\n    assert candidate('program') == \"not accepted\"\n    assert candidate('fine') == \"not accepted\"\n",
       "language": "python"
     },
     {
       "id": 688,
-      "input": "Write a function to get the length of a complex number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to get the length of a complex number.\nYour code should pass this test case: assert len_complex(3,4)==5.0",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(3,4)==5.0\n    assert candidate(9,10)==13.45362404707371\n    assert candidate(7,9)==11.40175425099138\n",
       "language": "python"
     },
     {
       "id": 491,
-      "input": "Write a function to find the sum of geometric progression series.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the sum of geometric progression series.\nYour code should pass this test case: assert sum_gp(1,5,2)==31",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(1,5,2)==31\n    assert candidate(1,5,4)==341\n    assert candidate(2,6,3)==728\n",
       "language": "python"
     },
     {
       "id": 635,
-      "input": "Write a function to push all values into a heap and then pop off the smallest values one at a time.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to push all values into a heap and then pop off the smallest values one at a time.\nYour code should pass this test case: assert heap_sort([1, 3, 5, 7, 9, 2, 4, 6, 8, 0])==[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 3, 5, 7, 9, 2, 4, 6, 8, 0])==[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]\n    assert candidate([25, 35, 22, 85, 14, 65, 75, 25, 58])==[14, 22, 25, 25, 35, 58, 65, 75, 85]\n    assert candidate( [7, 1, 9, 5])==[1,5,7,9]\n",
       "language": "python"
     },
     {
       "id": 775,
-      "input": "Write a python function to check whether every odd index contains odd numbers of a given list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether every odd index contains odd numbers of a given list.\nYour code should pass this test case: assert odd_position([2,1,4,3,6,7,6,3]) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([2,1,4,3,6,7,6,3]) == True\n    assert candidate([4,1,2]) == True\n    assert candidate([1,2,3]) == False\n",
       "language": "python"
     },
     {
       "id": 219,
-      "input": "Write a function to extract maximum and minimum k elements in the given tuple.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to extract maximum and minimum k elements in the given tuple.\nYour code should pass this test case: assert extract_min_max((5, 20, 3, 7, 6, 8), 2) == (3, 5, 8, 20)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((5, 20, 3, 7, 6, 8), 2) == (3, 5, 8, 20)\n    assert candidate((4, 5, 6, 1, 2, 7), 3) == (1, 2, 4, 5, 6, 7)\n    assert candidate((2, 3, 4, 8, 9, 11, 7), 4) == (2, 3, 4, 7, 8, 9, 11)\n",
       "language": "python"
     },
     {
       "id": 693,
-      "input": "Write a function to remove multiple spaces in a string by using regex.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to remove multiple spaces in a string by using regex.\nYour code should pass this test case: assert remove_multiple_spaces('Google      Assistant') == 'Google Assistant'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('Google      Assistant') == 'Google Assistant'\n    assert candidate('Quad      Core') == 'Quad Core'\n    assert candidate('ChromeCast      Built-in') == 'ChromeCast Built-in'\n",
       "language": "python"
     },
     {
       "id": 779,
-      "input": "Write a function to count the number of unique lists within a list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to count the number of unique lists within a list.\nYour code should pass this test case: assert unique_sublists([[1, 3], [5, 7], [1, 3], [13, 15, 17], [5, 7], [9, 11]])=={(1, 3): 2, (5, 7): 2, (13, 15, 17): 1, (9, 11): 1}",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[1, 3], [5, 7], [1, 3], [13, 15, 17], [5, 7], [9, 11]])=={(1, 3): 2, (5, 7): 2, (13, 15, 17): 1, (9, 11): 1}\n    assert candidate([['green', 'orange'], ['black'], ['green', 'orange'], ['white']])=={('green', 'orange'): 2, ('black',): 1, ('white',): 1}\n    assert candidate([[1, 2], [3, 4], [4, 5], [6, 7]])=={(1, 2): 1, (3, 4): 1, (4, 5): 1, (6, 7): 1}\n",
       "language": "python"
     },
     {
       "id": 124,
-      "input": "Write a function to get the angle of a complex number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to get the angle of a complex number.\nYour code should pass this test case: assert angle_complex(0,1j)==1.5707963267948966 ",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(0,1j)==1.5707963267948966 \n    assert candidate(2,1j)==0.4636476090008061\n    assert candidate(0,2j)==1.5707963267948966\n",
       "language": "python"
     },
     {
       "id": 726,
-      "input": "Write a function to multiply the adjacent elements of the given tuple.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to multiply the adjacent elements of the given tuple.\nYour code should pass this test case: assert multiply_elements((1, 5, 7, 8, 10)) == (5, 35, 56, 80)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((1, 5, 7, 8, 10)) == (5, 35, 56, 80)\n    assert candidate((2, 4, 5, 6, 7)) == (8, 20, 30, 42)\n    assert candidate((12, 13, 14, 9, 15)) == (156, 182, 126, 135)\n",
       "language": "python"
     },
     {
       "id": 155,
-      "input": "Write a python function to toggle all even bits of a given number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to toggle all even bits of a given number.\nYour code should pass this test case: assert even_bit_toggle_number(10) == 0",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10) == 0\n    assert candidate(20) == 30\n    assert candidate(30) == 20\n",
       "language": "python"
     },
     {
       "id": 474,
-      "input": "Write a function to replace characters in a string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to replace characters in a string.\nYour code should pass this test case: assert replace_char(\"polygon\",'y','l')==(\"pollgon\")",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"polygon\",'y','l')==(\"pollgon\")\n    assert candidate(\"character\",'c','a')==(\"aharaater\")\n    assert candidate(\"python\",'l','a')==(\"python\")\n",
       "language": "python"
     },
     {
       "id": 235,
-      "input": "Write a python function to set all even bits of a given number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to set all even bits of a given number.\nYour code should pass this test case: assert even_bit_set_number(10) == 10",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10) == 10\n    assert candidate(20) == 30\n    assert candidate(30) == 30\n",
       "language": "python"
     },
     {
       "id": 637,
-      "input": "Write a function to check whether the given amount has no profit and no loss",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check whether the given amount has no profit and no loss\nYour code should pass this test case: assert noprofit_noloss(1500,1200)==False",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(1500,1200)==False\n    assert candidate(100,100)==True\n    assert candidate(2000,5000)==False\n",
       "language": "python"
     },
     {
       "id": 371,
-      "input": "Write a function to find the smallest missing element in a sorted array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the smallest missing element in a sorted array.\nYour code should pass this test case: assert smallest_missing([0, 1, 2, 3, 4, 5, 6], 0, 6) == 7",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([0, 1, 2, 3, 4, 5, 6], 0, 6) == 7\n    assert candidate([0, 1, 2, 6, 9, 11, 15], 0, 6) == 3\n    assert candidate([1, 2, 3, 4, 6, 9, 11, 15], 0, 7) == 0\n",
       "language": "python"
     },
     {
       "id": 340,
-      "input": "Write a python function to find the sum of the three lowest positive numbers from a given list of numbers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the sum of the three lowest positive numbers from a given list of numbers.\nYour code should pass this test case: assert sum_three_smallest_nums([10,20,30,40,50,60,7]) == 37",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([10,20,30,40,50,60,7]) == 37\n    assert candidate([1,2,3,4,5]) == 6\n    assert candidate([0,1,2,3,4,5]) == 6\n",
       "language": "python"
     },
     {
       "id": 59,
-      "input": "Write a function to find the nth octagonal number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the nth octagonal number.\nYour code should pass this test case: assert is_octagonal(5) == 65",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(5) == 65\n    assert candidate(10) == 280\n    assert candidate(15) == 645\n",
       "language": "python"
     },
     {
       "id": 668,
-      "input": "Write a python function to replace multiple occurence of character by single.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to replace multiple occurence of character by single.\nYour code should pass this test case: assert replace('peep','e') == 'pep'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('peep','e') == 'pep'\n    assert candidate('Greek','e') == 'Grek'\n    assert candidate('Moon','o') == 'Mon'\n",
       "language": "python"
     },
     {
       "id": 482,
-      "input": "Write a function to find sequences of one upper case letter followed by lower case letters in the given string by using regex.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find sequences of one upper case letter followed by lower case letters in the given string by using regex.\nYour code should pass this test case: assert match(\"Geeks\") == 'Yes'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"Geeks\") == 'Yes'\n    assert candidate(\"geeksforGeeks\") == 'Yes'\n    assert candidate(\"geeks\") == 'No'\n",
       "language": "python"
     },
     {
       "id": 53,
-      "input": "Write a python function to check whether the first and last characters of a given string are equal or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether the first and last characters of a given string are equal or not.\nYour code should pass this test case: assert check_Equality(\"abcda\") == \"Equal\"",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"abcda\") == \"Equal\"\n    assert candidate(\"ab\") == \"Not Equal\"\n    assert candidate(\"mad\") == \"Not Equal\"\n",
       "language": "python"
     },
     {
       "id": 91,
-      "input": "Write a function to check if a substring is present in a given list of string values.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check if a substring is present in a given list of string values.\nYour code should pass this test case: assert find_substring([\"red\", \"black\", \"white\", \"green\", \"orange\"],\"ack\")==True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"],\"ack\")==True\n    assert candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"],\"abc\")==False\n    assert candidate([\"red\", \"black\", \"white\", \"green\", \"orange\"],\"ange\")==True\n",
       "language": "python"
     },
     {
       "id": 748,
-      "input": "Write a function to put spaces between words starting with capital letters in a given string by using regex.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to put spaces between words starting with capital letters in a given string by using regex.\nYour code should pass this test case: assert capital_words_spaces(\"Python\") == 'Python'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"Python\") == 'Python'\n    assert candidate(\"PythonProgrammingExamples\") == 'Python Programming Examples'\n    assert candidate(\"GetReadyToBeCodingFreak\") == 'Get Ready To Be Coding Freak'\n",
       "language": "python"
     },
     {
       "id": 915,
-      "input": "Write a function to rearrange positive and negative numbers in a given array using lambda function.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to rearrange positive and negative numbers in a given array using lambda function.\nYour code should pass this test case: assert rearrange_numbs([-1, 2, -3, 5, 7, 8, 9, -10])==[2, 5, 7, 8, 9, -10, -3, -1]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([-1, 2, -3, 5, 7, 8, 9, -10])==[2, 5, 7, 8, 9, -10, -3, -1]\n    assert candidate([10,15,14,13,-18,12,-20])==[10, 12, 13, 14, 15, -20, -18]\n    assert candidate([-20,20,-10,10,-30,30])==[10, 20, 30, -30, -20, -10]\n",
       "language": "python"
     },
     {
       "id": 523,
-      "input": "Write a function to check whether a given string has a capital letter, a lower case letter, a number and specified length using lambda function.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check whether a given string has a capital letter, a lower case letter, a number and specified length using lambda function.\nYour code should pass this test case: assert check_string('python')==['String must have 1 upper case character.', 'String must have 1 number.', 'String length should be atleast 8.']",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('python')==['String must have 1 upper case character.', 'String must have 1 number.', 'String length should be atleast 8.']\n    assert candidate('123python')==['String must have 1 upper case character.']\n    assert candidate('123Python')==['Valid string.']\n",
       "language": "python"
     },
     {
       "id": 563,
-      "input": "Write a function to extract values between quotation marks of a string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to extract values between quotation marks of a string.\nYour code should pass this test case: assert extract_values('\"Python\", \"PHP\", \"Java\"')==['Python', 'PHP', 'Java']",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('\"Python\", \"PHP\", \"Java\"')==['Python', 'PHP', 'Java']\n    assert candidate('\"python\",\"program\",\"language\"')==['python','program','language']\n    assert candidate('\"red\",\"blue\",\"green\",\"yellow\"')==['red','blue','green','yellow']\n",
       "language": "python"
     },
     {
       "id": 14,
-      "input": "Write a python function to find the volume of a triangular prism.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the volume of a triangular prism.\nYour code should pass this test case: assert find_Volume(10,8,6) == 240",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10,8,6) == 240\n    assert candidate(3,2,2) == 6\n    assert candidate(1,2,1) == 1\n",
       "language": "python"
     },
     {
       "id": 540,
-      "input": "Write a python function to find the difference between highest and least frequencies in a given array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the difference between highest and least frequencies in a given array.\nYour code should pass this test case: assert find_Diff([1,1,2,2,7,8,4,5,1,4],10) == 2",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,1,2,2,7,8,4,5,1,4],10) == 2\n    assert candidate([1,7,9,2,3,3,1,3,3],9) == 3\n    assert candidate([1,2,1,2],4) == 0\n",
       "language": "python"
     },
     {
       "id": 696,
-      "input": "Write a function to zip two given lists of lists.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to zip two given lists of lists.\nYour code should pass this test case: assert zip_list([[1, 3], [5, 7], [9, 11]] ,[[2, 4], [6, 8], [10, 12, 14]] )==[[1, 3, 2, 4], [5, 7, 6, 8], [9, 11, 10, 12, 14]]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[1, 3], [5, 7], [9, 11]] ,[[2, 4], [6, 8], [10, 12, 14]] )==[[1, 3, 2, 4], [5, 7, 6, 8], [9, 11, 10, 12, 14]]\n    assert candidate([[1, 2], [3, 4], [5, 6]] ,[[7, 8], [9, 10], [11, 12]] )==[[1, 2, 7, 8], [3, 4, 9, 10], [5, 6, 11, 12]]\n    assert candidate([['a','b'],['c','d']] , [['e','f'],['g','h']] )==[['a','b','e','f'],['c','d','g','h']]\n",
       "language": "python"
     },
     {
       "id": 44,
-      "input": "Write a function that matches a word at the beginning of a string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function that matches a word at the beginning of a string.\nYour code should pass this test case: assert text_match_string(\" python\")==('Not matched!')",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\" python\")==('Not matched!')\n    assert candidate(\"python\")==('Found a match!')\n    assert candidate(\"  lang\")==('Not matched!')\n    assert candidate(\"foo\")==('Found a match!')\n",
       "language": "python"
     },
     {
       "id": 544,
-      "input": "Write a function to flatten the tuple list to a string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to flatten the tuple list to a string.\nYour code should pass this test case: assert flatten_tuple([('1', '4', '6'), ('5', '8'), ('2', '9'), ('1', '10')]) == '1 4 6 5 8 2 9 1 10'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([('1', '4', '6'), ('5', '8'), ('2', '9'), ('1', '10')]) == '1 4 6 5 8 2 9 1 10'\n    assert candidate([('2', '3', '4'), ('6', '9'), ('3', '2'), ('2', '11')]) == '2 3 4 6 9 3 2 2 11'\n    assert candidate([('14', '21', '9'), ('24', '19'), ('12', '29'), ('23', '17')]) == '14 21 9 24 19 12 29 23 17'\n",
       "language": "python"
     },
     {
       "id": 360,
-      "input": "Write a function to find the n\u2019th carol number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the n\u2019th carol number.\nYour code should pass this test case: assert get_carol(2) == 7",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(2) == 7\n    assert candidate(4) == 223\n    assert candidate(5) == 959\n",
       "language": "python"
     },
     {
       "id": 769,
-      "input": "Write a python function to get the difference between two lists.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to get the difference between two lists.\nYour code should pass this test case: assert (Diff([10, 15, 20, 25, 30, 35, 40], [25, 40, 35])) == [10, 20, 30, 15]",
       "test": "",
       "language": "python"
     },
     {
       "id": 480,
-      "input": "Write a python function to find the maximum occurring character in a given string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the maximum occurring character in a given string.\nYour code should pass this test case: assert get_max_occuring_char(\"data\") == \"a\"",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"data\") == \"a\"\n    assert candidate(\"create\") == \"e\"\n    assert candidate(\"brilliant girl\") == \"i\"\n",
       "language": "python"
     },
     {
       "id": 957,
-      "input": "Write a python function to get the position of rightmost set bit.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to get the position of rightmost set bit.\nYour code should pass this test case: assert get_First_Set_Bit_Pos(12) == 3",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(12) == 3\n    assert candidate(18) == 2\n    assert candidate(16) == 5\n",
       "language": "python"
     },
     {
       "id": 561,
-      "input": "Write a function to assign with each element, its pair elements from other similar pairs in the given tuple.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to assign with each element, its pair elements from other similar pairs in the given tuple.\nYour code should pass this test case: assert assign_elements([(5, 3), (7, 5), (2, 7), (3, 8), (8, 4)] ) == {3: [8], 5: [3], 7: [5], 2: [7], 8: [4], 4: []}",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([(5, 3), (7, 5), (2, 7), (3, 8), (8, 4)] ) == {3: [8], 5: [3], 7: [5], 2: [7], 8: [4], 4: []}\n    assert candidate([(6, 4), (9, 4), (3, 8), (4, 9), (9, 5)] ) == {4: [9], 6: [4], 9: [4, 5], 8: [], 3: [8], 5: []}\n    assert candidate([(6, 2), (6, 8), (4, 9), (4, 9), (3, 7)] ) == {2: [], 6: [2, 8], 8: [], 9: [], 4: [9, 9], 7: [], 3: [7]}\n",
       "language": "python"
     },
     {
       "id": 809,
-      "input": "Write a function to check if each element of second tuple is smaller than its corresponding index in first tuple.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check if each element of second tuple is smaller than its corresponding index in first tuple.\nYour code should pass this test case: assert check_smaller((1, 2, 3), (2, 3, 4)) == False",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((1, 2, 3), (2, 3, 4)) == False\n    assert candidate((4, 5, 6), (3, 4, 5)) == True\n    assert candidate((11, 12, 13), (10, 11, 12)) == True\n",
       "language": "python"
     },
     {
       "id": 136,
-      "input": "Write a function to calculate electricity bill.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to calculate electricity bill.\nYour code should pass this test case: assert cal_electbill(75)==246.25",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(75)==246.25\n    assert candidate(265)==1442.75\n    assert candidate(100)==327.5\n",
       "language": "python"
     },
     {
       "id": 866,
-      "input": "Write a function to check whether the given month name contains 31 days or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check whether the given month name contains 31 days or not.\nYour code should pass this test case: assert check_monthnumb(\"February\")==False",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"February\")==False\n    assert candidate(\"January\")==True\n    assert candidate(\"March\")==True\n",
       "language": "python"
     },
     {
       "id": 83,
-      "input": "Write a python function to find the character made by adding all the characters of the given string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the character made by adding all the characters of the given string.\nYour code should pass this test case: assert get_Char(\"abc\") == \"f\"",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"abc\") == \"f\"\n    assert candidate(\"gfg\") == \"t\"\n    assert candidate(\"ab\") == \"c\"\n",
       "language": "python"
     },
     {
       "id": 763,
-      "input": "Write a python function to find the minimum difference between any two elements in a given array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the minimum difference between any two elements in a given array.\nYour code should pass this test case: assert find_Min_Diff((1,5,3,19,18,25),6) == 1",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((1,5,3,19,18,25),6) == 1\n    assert candidate((4,3,2,6),4) == 1\n    assert candidate((30,5,20,9),4) == 4\n",
       "language": "python"
     },
     {
       "id": 10,
-      "input": "Write a function to get the n smallest items from a dataset.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to get the n smallest items from a dataset.\nYour code should pass this test case: assert small_nnum([10, 20, 50, 70, 90, 20, 50, 40, 60, 80, 100],2)==[10,20]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([10, 20, 50, 70, 90, 20, 50, 40, 60, 80, 100],2)==[10,20]\n    assert candidate([10, 20, 50, 70, 90, 20, 50, 40, 60, 80, 100],5)==[10,20,20,40,50]\n    assert candidate([10, 20, 50, 70, 90, 20, 50, 40, 60, 80, 100],3)==[10,20,20]\n",
       "language": "python"
     },
     {
       "id": 439,
-      "input": "Write a function to convert a list of multiple integers into a single integer.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to convert a list of multiple integers into a single integer.\nYour code should pass this test case: assert multiple_to_single([11, 33, 50])==113350",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([11, 33, 50])==113350\n    assert candidate([-1,2,3,4,5,6])==-123456\n    assert candidate([10,15,20,25])==10152025\n",
       "language": "python"
     },
     {
       "id": 643,
-      "input": "Write a function that matches a word containing 'z', not at the start or end of the word.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function that matches a word containing 'z', not at the start or end of the word.\nYour code should pass this test case: assert text_match_wordz_middle(\"pythonzabc.\")==('Found a match!')",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"pythonzabc.\")==('Found a match!')\n    assert candidate(\"xyzabc.\")==('Found a match!')\n    assert candidate(\"  lang  .\")==('Not matched!')\n",
       "language": "python"
     },
     {
       "id": 591,
-      "input": "Write a python function to interchange the first and last elements in a list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to interchange the first and last elements in a list.\nYour code should pass this test case: assert swap_List([12, 35, 9, 56, 24]) == [24, 35, 9, 56, 12]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([12, 35, 9, 56, 24]) == [24, 35, 9, 56, 12]\n    assert candidate([1, 2, 3]) == [3, 2, 1]\n    assert candidate([4, 5, 6]) == [6, 5, 4]\n",
       "language": "python"
     },
     {
       "id": 258,
-      "input": "Write a function to find number of odd elements in the given list using lambda function.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find number of odd elements in the given list using lambda function.\nYour code should pass this test case: assert count_odd([1, 2, 3, 5, 7, 8, 10])==4",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 2, 3, 5, 7, 8, 10])==4\n    assert candidate([10,15,14,13,-18,12,-20])==2\n    assert candidate([1, 2, 4, 8, 9])==2\n",
       "language": "python"
     },
     {
       "id": 35,
-      "input": "Write a function to find the n-th rectangular number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the n-th rectangular number.\nYour code should pass this test case: assert find_rect_num(4) == 20",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(4) == 20\n    assert candidate(5) == 30\n    assert candidate(6) == 42\n",
       "language": "python"
     },
     {
       "id": 366,
-      "input": "Write a python function to find the largest product of the pair of adjacent elements from a given list of integers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the largest product of the pair of adjacent elements from a given list of integers.\nYour code should pass this test case: assert adjacent_num_product([1,2,3,4,5,6]) == 30",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,3,4,5,6]) == 30\n    assert candidate([1,2,3,4,5]) == 20\n    assert candidate([2,3]) == 6\n",
       "language": "python"
     },
     {
       "id": 711,
-      "input": "Write a python function to check whether the product of digits of a number at even and odd places is equal or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether the product of digits of a number at even and odd places is equal or not.\nYour code should pass this test case: assert product_Equal(2841) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(2841) == True\n    assert candidate(1234) == False\n    assert candidate(1212) == False\n",
       "language": "python"
     },
     {
       "id": 137,
-      "input": "Write a function to find the ration of zeroes in an array of integers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the ration of zeroes in an array of integers.\nYour code should pass this test case: assert zero_count([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8])==0.15",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8])==0.15\n    assert candidate([2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8])==0.00\n    assert candidate([2, 4, -6, -9, 11, -12, 14, -5, 17])==0.00\n",
       "language": "python"
     },
     {
       "id": 657,
-      "input": "Write a python function to find the first digit in factorial of a given number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the first digit in factorial of a given number.\nYour code should pass this test case: assert first_Digit(5) == 1",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(5) == 1\n    assert candidate(10) == 3\n    assert candidate(7) == 5\n",
       "language": "python"
     },
     {
       "id": 150,
-      "input": "Write a python function to find whether the given number is present in the infinite sequence or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find whether the given number is present in the infinite sequence or not.\nYour code should pass this test case: assert does_Contain_B(1,7,3) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(1,7,3) == True\n    assert candidate(1,-3,5) == False\n    assert candidate(3,2,5) == False\n",
       "language": "python"
     },
     {
       "id": 889,
-      "input": "Write a function to reverse each list in a given list of lists.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to reverse each list in a given list of lists.\nYour code should pass this test case: assert reverse_list_lists([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]])==[[4, 3, 2, 1], [8, 7, 6, 5], [12, 11, 10, 9], [16, 15, 14, 13]]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]])==[[4, 3, 2, 1], [8, 7, 6, 5], [12, 11, 10, 9], [16, 15, 14, 13]]\n    assert candidate([[1,2],[2,3],[3,4]])==[[2,1],[3,2],[4,3]]\n    assert candidate([[10,20],[30,40]])==[[20,10],[40,30]]\n",
       "language": "python"
     },
     {
       "id": 42,
-      "input": "Write a python function to find the sum of repeated elements in a given array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the sum of repeated elements in a given array.\nYour code should pass this test case: assert find_Sum([1,2,3,1,1,4,5,6],8) == 3",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,3,1,1,4,5,6],8) == 3\n    assert candidate([1,2,3,1,1],5) == 3\n    assert candidate([1,1,2],3) == 2\n    assert candidate([1,1,2,3,4,5,6,3,5],9) == 18\n",
       "language": "python"
     },
     {
       "id": 783,
-      "input": "Write a function to convert rgb color to hsv color.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to convert rgb color to hsv color.\nYour code should pass this test case: assert rgb_to_hsv(255, 255, 255)==(0, 0.0, 100.0)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(255, 255, 255)==(0, 0.0, 100.0)\n    assert candidate(0, 215, 0)==(120.0, 100.0, 84.31372549019608)\n    assert candidate(10, 215, 110)==(149.26829268292684, 95.34883720930233, 84.31372549019608)\n",
       "language": "python"
     },
     {
       "id": 582,
-      "input": "Write a function to check if a dictionary is empty or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check if a dictionary is empty or not.\nYour code should pass this test case: assert my_dict({10})==False",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate({10})==False\n    assert candidate({11})==False\n    assert candidate({})==True\n",
       "language": "python"
     },
     {
       "id": 75,
-      "input": "Write a function to find tuples which have all elements divisible by k from the given list of tuples.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find tuples which have all elements divisible by k from the given list of tuples.\nYour code should pass this test case: assert find_tuples([(6, 24, 12), (7, 9, 6), (12, 18, 21)], 6) == '[(6, 24, 12)]'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([(6, 24, 12), (7, 9, 6), (12, 18, 21)], 6) == '[(6, 24, 12)]'\n    assert candidate([(5, 25, 30), (4, 2, 3), (7, 8, 9)], 5) == '[(5, 25, 30)]'\n    assert candidate([(7, 9, 16), (8, 16, 4), (19, 17, 18)], 4) == '[(8, 16, 4)]'\n",
       "language": "python"
     },
     {
       "id": 399,
-      "input": "Write a function to perform the mathematical bitwise xor operation across the given tuples.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to perform the mathematical bitwise xor operation across the given tuples.\nYour code should pass this test case: assert bitwise_xor((10, 4, 6, 9), (5, 2, 3, 3)) == (15, 6, 5, 10)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((10, 4, 6, 9), (5, 2, 3, 3)) == (15, 6, 5, 10)\n    assert candidate((11, 5, 7, 10), (6, 3, 4, 4)) == (13, 6, 3, 14)\n    assert candidate((12, 6, 8, 11), (7, 4, 5, 6)) == (11, 2, 13, 13)\n",
       "language": "python"
     },
     {
       "id": 730,
-      "input": "Write a function to remove consecutive duplicates of a given list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to remove consecutive duplicates of a given list.\nYour code should pass this test case: assert consecutive_duplicates([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4 ])==[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4 ])==[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4]\n    assert candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10])==[10, 15, 19, 18, 17, 26, 17, 18, 10]\n    assert candidate(['a', 'a', 'b', 'c', 'd', 'd'])==['a', 'b', 'c', 'd']\n",
       "language": "python"
     },
     {
       "id": 198,
-      "input": "Write a function to find the largest triangle that can be inscribed in an ellipse.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the largest triangle that can be inscribed in an ellipse.\nYour code should pass this test case: assert largest_triangle(4,2)==10.392304845413264",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(4,2)==10.392304845413264\n    assert candidate(5,7)==4.639421805988064\n    assert candidate(9,1)==105.2220865598093\n",
       "language": "python"
     },
     {
       "id": 497,
-      "input": "Write a function to find the surface area of a cone.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the surface area of a cone.\nYour code should pass this test case: assert surfacearea_cone(5,12)==282.7433388230814",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(5,12)==282.7433388230814\n    assert candidate(10,15)==880.5179353159282\n    assert candidate(19,17)==2655.923961165254\n",
       "language": "python"
     },
     {
       "id": 708,
-      "input": "Write a python function to convert a string to a list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to convert a string to a list.\nYour code should pass this test case: assert Convert('python program') == ['python','program']",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('python program') == ['python','program']\n    assert candidate('Data Analysis') ==['Data','Analysis']\n    assert candidate('Hadoop Training') == ['Hadoop','Training']\n",
       "language": "python"
     },
     {
       "id": 294,
-      "input": "Write a function to find the maximum value in a given heterogeneous list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the maximum value in a given heterogeneous list.\nYour code should pass this test case: assert max_val(['Python', 3, 2, 4, 5, 'version'])==5",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(['Python', 3, 2, 4, 5, 'version'])==5\n    assert candidate(['Python', 15, 20, 25])==25\n    assert candidate(['Python', 30, 20, 40, 50, 'version'])==50\n",
       "language": "python"
     },
     {
       "id": 793,
-      "input": "Write a python function to find the last position of an element in a sorted array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the last position of an element in a sorted array.\nYour code should pass this test case: assert last([1,2,3],1,3) == 0",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,3],1,3) == 0\n    assert candidate([1,1,1,2,3,4],1,6) == 2\n    assert candidate([2,3,2,3,6,8,9],3,8) == 3\n",
       "language": "python"
     },
     {
       "id": 721,
-      "input": "Write a function to find a path with the maximum average over all existing paths for the given square matrix of size n*n.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find a path with the maximum average over all existing paths for the given square matrix of size n*n.\nYour code should pass this test case: assert maxAverageOfPath([[1, 2, 3], [6, 5, 4], [7, 3, 9]], 3) == 5.2",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[1, 2, 3], [6, 5, 4], [7, 3, 9]], 3) == 5.2\n    assert candidate([[2, 3, 4], [7, 6, 5], [8, 4, 10]], 3) == 6.2\n    assert candidate([[3, 4, 5], [8, 7, 6], [9, 5, 11]], 3) == 7.2 \n",
       "language": "python"
     },
     {
       "id": 336,
-      "input": "Write a function to check whether the given month name contains 28 days or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check whether the given month name contains 28 days or not.\nYour code should pass this test case: assert check_monthnum(\"February\")==True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"February\")==True\n    assert candidate(\"January\")==False\n    assert candidate(\"March\")==False\n",
       "language": "python"
     },
     {
       "id": 887,
-      "input": "Write a python function to check whether the given number is odd or not using bitwise operator.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether the given number is odd or not using bitwise operator.\nYour code should pass this test case: assert is_odd(5) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(5) == True\n    assert candidate(6) == False\n    assert candidate(7) == True\n",
       "language": "python"
     },
     {
       "id": 43,
-      "input": "Write a function to find sequences of lowercase letters joined with an underscore using regex.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find sequences of lowercase letters joined with an underscore using regex.\nYour code should pass this test case: assert text_match(\"aab_cbbbc\") == 'Found a match!'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"aab_cbbbc\") == 'Found a match!'\n    assert candidate(\"aab_Abbbc\") == 'Not matched!'\n    assert candidate(\"Aaab_abbbc\") == 'Not matched!'\n    assert candidate(\"aab-cbbbc\") == 'Not matched!'\n",
       "language": "python"
     },
     {
       "id": 473,
-      "input": "Write a function to find the tuple intersection of elements in the given tuple list irrespective of their order.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the tuple intersection of elements in the given tuple list irrespective of their order.\nYour code should pass this test case: assert tuple_intersection([(3, 4), (5, 6), (9, 10), (4, 5)] , [(5, 4), (3, 4), (6, 5), (9, 11)]) == {(4, 5), (3, 4), (5, 6)}",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([(3, 4), (5, 6), (9, 10), (4, 5)] , [(5, 4), (3, 4), (6, 5), (9, 11)]) == {(4, 5), (3, 4), (5, 6)}\n    assert candidate([(4, 1), (7, 4), (11, 13), (17, 14)] , [(1, 4), (7, 4), (16, 12), (10, 13)]) == {(4, 7), (1, 4)}\n    assert candidate([(2, 1), (3, 2), (1, 3), (1, 4)] , [(11, 2), (2, 3), (6, 2), (1, 3)]) == {(1, 3), (2, 3)}\n",
       "language": "python"
     },
     {
       "id": 457,
-      "input": "Write a python function to find the sublist having minimum length.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the sublist having minimum length.\nYour code should pass this test case: assert Find_Min([[1],[1,2],[1,2,3]]) == [1]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[1],[1,2],[1,2,3]]) == [1]\n    assert candidate([[1,1],[1,1,1],[1,2,7,8]]) == [1,1]\n    assert candidate([['x'],['x','y'],['x','y','z']]) == ['x']\n",
       "language": "python"
     },
     {
       "id": 584,
-      "input": "Write a function to find all adverbs and their positions in a given sentence by using regex.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find all adverbs and their positions in a given sentence by using regex.\nYour code should pass this test case: assert find_adverbs(\"Clearly, he has no excuse for such behavior.\") == '0-7: Clearly'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"Clearly, he has no excuse for such behavior.\") == '0-7: Clearly'\n    assert candidate(\"Please handle the situation carefuly\") == '28-36: carefuly'\n    assert candidate(\"Complete the task quickly\") == '18-25: quickly'\n",
       "language": "python"
     },
     {
       "id": 707,
-      "input": "Write a python function to count the total set bits from 1 to n.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count the total set bits from 1 to n.\nYour code should pass this test case: assert count_Set_Bits(16) == 33",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(16) == 33\n    assert candidate(2) == 2\n    assert candidate(14) == 28\n",
       "language": "python"
     },
     {
       "id": 423,
-      "input": "Write a function to solve gold mine problem.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to solve gold mine problem.\nYour code should pass this test case: assert get_maxgold([[1, 3, 1, 5],[2, 2, 4, 1],[5, 0, 2, 3],[0, 6, 1, 2]],4,4)==16",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[1, 3, 1, 5],[2, 2, 4, 1],[5, 0, 2, 3],[0, 6, 1, 2]],4,4)==16\n    assert candidate([[10,20],[30,40]],2,2)==70\n    assert candidate([[4,9],[3,7]],2,2)==13\n",
       "language": "python"
     },
     {
       "id": 347,
-      "input": "Write a python function to count the number of squares in a rectangle.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count the number of squares in a rectangle.\nYour code should pass this test case: assert count_Squares(4,3) == 20",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(4,3) == 20\n    assert candidate(1,2) == 2\n    assert candidate(2,2) == 5\n",
       "language": "python"
     },
     {
       "id": 215,
-      "input": "Write a function to decode a run-length encoded given list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to decode a run-length encoded given list.\nYour code should pass this test case: assert decode_list([[2, 1], 2, 3, [2, 4], 5,1])==[1,1,2,3,4,4,5,1]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[2, 1], 2, 3, [2, 4], 5,1])==[1,1,2,3,4,4,5,1]\n    assert candidate(['a', 'u', 't', 'o', 'm', 'a', 't', 'i', 'c', 'a', [2, 'l'], 'y'])==['a', 'u', 't', 'o', 'm', 'a', 't', 'i', 'c', 'a', 'l', 'l', 'y']\n    assert candidate(['p', 'y', 't', 'h', 'o', 'n'])==['p', 'y', 't', 'h', 'o', 'n']\n",
       "language": "python"
     },
     {
       "id": 356,
-      "input": "Write a function to find the third angle of a triangle using two angles.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the third angle of a triangle using two angles.\nYour code should pass this test case: assert find_angle(47,89)==44",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(47,89)==44\n    assert candidate(45,95)==40\n    assert candidate(50,40)==90\n",
       "language": "python"
     },
     {
       "id": 386,
-      "input": "Write a function to find out the minimum no of swaps required for bracket balancing in the given string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find out the minimum no of swaps required for bracket balancing in the given string.\nYour code should pass this test case: assert swap_count(\"[]][][\") == 2",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"[]][][\") == 2\n    assert candidate(\"[[][]]\") == 0\n    assert candidate(\"[[][]]][\") == 1\n",
       "language": "python"
     },
     {
       "id": 364,
-      "input": "Write a function to find the number of flips required to make the given binary string a sequence of alternate characters.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the number of flips required to make the given binary string a sequence of alternate characters.\nYour code should pass this test case: assert min_flip_to_make_string_alternate(\"0001010111\") == 2",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"0001010111\") == 2\n    assert candidate(\"001\") == 1\n    assert candidate(\"010111011\") == 2 \n",
       "language": "python"
     },
     {
       "id": 907,
-      "input": "Write a function to print the first n lucky numbers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to print the first n lucky numbers.\nYour code should pass this test case: assert lucky_num(10)==[1, 3, 7, 9, 13, 15, 21, 25, 31, 33] ",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10)==[1, 3, 7, 9, 13, 15, 21, 25, 31, 33] \n    assert candidate(5)==[1, 3, 7, 9, 13]\n    assert candidate(8)==[1, 3, 7, 9, 13, 15, 21, 25]\n",
       "language": "python"
     },
     {
       "id": 493,
-      "input": "Write a function to calculate a grid of hexagon coordinates where function returns a list of lists containing 6 tuples of x, y point coordinates.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to calculate a grid of hexagon coordinates where function returns a list of lists containing 6 tuples of x, y point coordinates.\nYour code should pass this test case: assert calculate_polygons(1,1, 4, 4, 3)==[[(-5.0, -4.196152422706632), (-5.0, -0.7320508075688767), (-2.0, 1.0), (1.0, -0.7320508075688767), (1.0, -4.196152422706632), (-2.0, -5.928203230275509), (-5.0, -4.196152422706632)], [(1.0, -4.196152422706632), (1.0, -0.7320508075688767), (4.0, 1.0), (7.0, -0.7320508075688767), (7.0, -4.196152422706632), (4.0, -5.928203230275509), (1.0, -4.196152422706632)], [(7.0, -4.196152422706632), (7.0, -0.7320508075688767), (10.0, 1.0), (13.0, -0.7320508075688767), (13.0, -4.196152422706632), (10.0, -5.928203230275509), (7.0, -4.196152422706632)], [(-2.0, 1.0000000000000004), (-2.0, 4.464101615137755), (1.0, 6.196152422706632), (4.0, 4.464101615137755), (4.0, 1.0000000000000004), (1.0, -0.7320508075688767), (-2.0, 1.0000000000000004)], [(4.0, 1.0000000000000004), (4.0, 4.464101615137755), (7.0, 6.196152422706632), (10.0, 4.464101615137755), (10.0, 1.0000000000000004), (7.0, -0.7320508075688767), (4.0, 1.0000000000000004)], [(-5.0, 6.196152422706632), (-5.0, 9.660254037844387), (-2.0, 11.392304845413264), (1.0, 9.660254037844387), (1.0, 6.196152422706632), (-2.0, 4.464101615137755), (-5.0, 6.196152422706632)], [(1.0, 6.196152422706632), (1.0, 9.660254037844387), (4.0, 11.392304845413264), (7.0, 9.660254037844387), (7.0, 6.196152422706632), (4.0, 4.464101615137755), (1.0, 6.196152422706632)], [(7.0, 6.196152422706632), (7.0, 9.660254037844387), (10.0, 11.392304845413264), (13.0, 9.660254037844387), (13.0, 6.196152422706632), (10.0, 4.464101615137755), (7.0, 6.196152422706632)], [(-2.0, 11.392304845413264), (-2.0, 14.85640646055102), (1.0, 16.588457268119896), (4.0, 14.85640646055102), (4.0, 11.392304845413264), (1.0, 9.660254037844387), (-2.0, 11.392304845413264)], [(4.0, 11.392304845413264), (4.0, 14.85640646055102), (7.0, 16.588457268119896), (10.0, 14.85640646055102), (10.0, 11.392304845413264), (7.0, 9.660254037844387), (4.0, 11.392304845413264)]]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(1,1, 4, 4, 3)==[[(-5.0, -4.196152422706632), (-5.0, -0.7320508075688767), (-2.0, 1.0), (1.0, -0.7320508075688767), (1.0, -4.196152422706632), (-2.0, -5.928203230275509), (-5.0, -4.196152422706632)], [(1.0, -4.196152422706632), (1.0, -0.7320508075688767), (4.0, 1.0), (7.0, -0.7320508075688767), (7.0, -4.196152422706632), (4.0, -5.928203230275509), (1.0, -4.196152422706632)], [(7.0, -4.196152422706632), (7.0, -0.7320508075688767), (10.0, 1.0), (13.0, -0.7320508075688767), (13.0, -4.196152422706632), (10.0, -5.928203230275509), (7.0, -4.196152422706632)], [(-2.0, 1.0000000000000004), (-2.0, 4.464101615137755), (1.0, 6.196152422706632), (4.0, 4.464101615137755), (4.0, 1.0000000000000004), (1.0, -0.7320508075688767), (-2.0, 1.0000000000000004)], [(4.0, 1.0000000000000004), (4.0, 4.464101615137755), (7.0, 6.196152422706632), (10.0, 4.464101615137755), (10.0, 1.0000000000000004), (7.0, -0.7320508075688767), (4.0, 1.0000000000000004)], [(-5.0, 6.196152422706632), (-5.0, 9.660254037844387), (-2.0, 11.392304845413264), (1.0, 9.660254037844387), (1.0, 6.196152422706632), (-2.0, 4.464101615137755), (-5.0, 6.196152422706632)], [(1.0, 6.196152422706632), (1.0, 9.660254037844387), (4.0, 11.392304845413264), (7.0, 9.660254037844387), (7.0, 6.196152422706632), (4.0, 4.464101615137755), (1.0, 6.196152422706632)], [(7.0, 6.196152422706632), (7.0, 9.660254037844387), (10.0, 11.392304845413264), (13.0, 9.660254037844387), (13.0, 6.196152422706632), (10.0, 4.464101615137755), (7.0, 6.196152422706632)], [(-2.0, 11.392304845413264), (-2.0, 14.85640646055102), (1.0, 16.588457268119896), (4.0, 14.85640646055102), (4.0, 11.392304845413264), (1.0, 9.660254037844387), (-2.0, 11.392304845413264)], [(4.0, 11.392304845413264), (4.0, 14.85640646055102), (7.0, 16.588457268119896), (10.0, 14.85640646055102), (10.0, 11.392304845413264), (7.0, 9.660254037844387), (4.0, 11.392304845413264)]]\n    assert candidate(5,4,7,9,8)==[[(-11.0, -9.856406460551018), (-11.0, -0.6188021535170058), (-3.0, 4.0), (5.0, -0.6188021535170058), (5.0, -9.856406460551018), (-3.0, -14.475208614068023), (-11.0, -9.856406460551018)], [(5.0, -9.856406460551018), (5.0, -0.6188021535170058), (13.0, 4.0), (21.0, -0.6188021535170058), (21.0, -9.856406460551018), (13.0, -14.475208614068023), (5.0, -9.856406460551018)], [(21.0, -9.856406460551018), (21.0, -0.6188021535170058), (29.0, 4.0), (37.0, -0.6188021535170058), (37.0, -9.856406460551018), (29.0, -14.475208614068023), (21.0, -9.856406460551018)], [(-3.0, 4.0), (-3.0, 13.237604307034012), (5.0, 17.856406460551018), (13.0, 13.237604307034012), (13.0, 4.0), (5.0, -0.6188021535170058), (-3.0, 4.0)], [(13.0, 4.0), (13.0, 13.237604307034012), (21.0, 17.856406460551018), (29.0, 13.237604307034012), (29.0, 4.0), (21.0, -0.6188021535170058), (13.0, 4.0)], [(-11.0, 17.856406460551018), (-11.0, 27.09401076758503), (-3.0, 31.712812921102035), (5.0, 27.09401076758503), (5.0, 17.856406460551018), (-3.0, 13.237604307034012), (-11.0, 17.856406460551018)], [(5.0, 17.856406460551018), (5.0, 27.09401076758503), (13.0, 31.712812921102035), (21.0, 27.09401076758503), (21.0, 17.856406460551018), (13.0, 13.237604307034012), (5.0, 17.856406460551018)], [(21.0, 17.856406460551018), (21.0, 27.09401076758503), (29.0, 31.712812921102035), (37.0, 27.09401076758503), (37.0, 17.856406460551018), (29.0, 13.237604307034012), (21.0, 17.856406460551018)], [(-3.0, 31.712812921102035), (-3.0, 40.95041722813605), (5.0, 45.569219381653056), (13.0, 40.95041722813605), (13.0, 31.712812921102035), (5.0, 27.09401076758503), (-3.0, 31.712812921102035)], [(13.0, 31.712812921102035), (13.0, 40.95041722813605), (21.0, 45.569219381653056), (29.0, 40.95041722813605), (29.0, 31.712812921102035), (21.0, 27.09401076758503), (13.0, 31.712812921102035)]]\n    assert candidate(9,6,4,3,2)==[[(5.0, 2.5358983848622456), (5.0, 4.8452994616207485), (7.0, 6.0), (9.0, 4.8452994616207485), (9.0, 2.5358983848622456), (7.0, 1.3811978464829942), (5.0, 2.5358983848622456)], [(7.0, 6.0), (7.0, 8.309401076758503), (9.0, 9.464101615137753), (11.0, 8.309401076758503), (11.0, 6.0), (9.0, 4.8452994616207485), (7.0, 6.0)]]\n",
       "language": "python"
     },
     {
       "id": 316,
-      "input": "Write a function to find the index of the last occurrence of a given number in a sorted array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the index of the last occurrence of a given number in a sorted array.\nYour code should pass this test case: assert find_last_occurrence([2, 5, 5, 5, 6, 6, 8, 9, 9, 9], 5) == 3",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([2, 5, 5, 5, 6, 6, 8, 9, 9, 9], 5) == 3\n    assert candidate([2, 3, 5, 8, 6, 6, 8, 9, 9, 9], 9) == 9\n    assert candidate([2, 2, 1, 5, 6, 6, 6, 9, 9, 9], 6) == 6\n",
       "language": "python"
     },
     {
       "id": 462,
-      "input": "Write a function to find all possible combinations of the elements of a given list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find all possible combinations of the elements of a given list.\nYour code should pass this test case: assert combinations_list(['orange', 'red', 'green', 'blue'])==[[], ['orange'], ['red'], ['red', 'orange'], ['green'], ['green', 'orange'], ['green', 'red'], ['green', 'red', 'orange'], ['blue'], ['blue', 'orange'], ['blue', 'red'], ['blue', 'red', 'orange'], ['blue', 'green'], ['blue', 'green', 'orange'], ['blue', 'green', 'red'], ['blue', 'green', 'red', 'orange']]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(['orange', 'red', 'green', 'blue'])==[[], ['orange'], ['red'], ['red', 'orange'], ['green'], ['green', 'orange'], ['green', 'red'], ['green', 'red', 'orange'], ['blue'], ['blue', 'orange'], ['blue', 'red'], ['blue', 'red', 'orange'], ['blue', 'green'], ['blue', 'green', 'orange'], ['blue', 'green', 'red'], ['blue', 'green', 'red', 'orange']]\n    assert candidate(['red', 'green', 'blue', 'white', 'black', 'orange'])==[[], ['red'], ['green'], ['green', 'red'], ['blue'], ['blue', 'red'], ['blue', 'green'], ['blue', 'green', 'red'], ['white'], ['white', 'red'], ['white', 'green'], ['white', 'green', 'red'], ['white', 'blue'], ['white', 'blue', 'red'], ['white', 'blue', 'green'], ['white', 'blue', 'green', 'red'], ['black'], ['black', 'red'], ['black', 'green'], ['black', 'green', 'red'], ['black', 'blue'], ['black', 'blue', 'red'], ['black', 'blue', 'green'], ['black', 'blue', 'green', 'red'], ['black', 'white'], ['black', 'white', 'red'], ['black', 'white', 'green'], ['black', 'white', 'green', 'red'], ['black', 'white', 'blue'], ['black', 'white', 'blue', 'red'], ['black', 'white', 'blue', 'green'], ['black', 'white', 'blue', 'green', 'red'], ['orange'], ['orange', 'red'], ['orange', 'green'], ['orange', 'green', 'red'], ['orange', 'blue'], ['orange', 'blue', 'red'], ['orange', 'blue', 'green'], ['orange', 'blue', 'green', 'red'], ['orange', 'white'], ['orange', 'white', 'red'], ['orange', 'white', 'green'], ['orange', 'white', 'green', 'red'], ['orange', 'white', 'blue'], ['orange', 'white', 'blue', 'red'], ['orange', 'white', 'blue', 'green'], ['orange', 'white', 'blue', 'green', 'red'], ['orange', 'black'], ['orange', 'black', 'red'], ['orange', 'black', 'green'], ['orange', 'black', 'green', 'red'], ['orange', 'black', 'blue'], ['orange', 'black', 'blue', 'red'], ['orange', 'black', 'blue', 'green'], ['orange', 'black', 'blue', 'green', 'red'], ['orange', 'black', 'white'], ['orange', 'black', 'white', 'red'], ['orange', 'black', 'white', 'green'], ['orange', 'black', 'white', 'green', 'red'], ['orange', 'black', 'white', 'blue'], ['orange', 'black', 'white', 'blue', 'red'], ['orange', 'black', 'white', 'blue', 'green'], ['orange', 'black', 'white', 'blue', 'green', 'red']]\n    assert candidate(['red', 'green', 'black', 'orange'])==[[], ['red'], ['green'], ['green', 'red'], ['black'], ['black', 'red'], ['black', 'green'], ['black', 'green', 'red'], ['orange'], ['orange', 'red'], ['orange', 'green'], ['orange', 'green', 'red'], ['orange', 'black'], ['orange', 'black', 'red'], ['orange', 'black', 'green'], ['orange', 'black', 'green', 'red']]\n",
       "language": "python"
     },
     {
       "id": 595,
-      "input": "Write a python function to count minimum number of swaps required to convert one binary string to another.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count minimum number of swaps required to convert one binary string to another.\nYour code should pass this test case: assert min_Swaps(\"1101\",\"1110\") == 1",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"1101\",\"1110\") == 1\n    assert candidate(\"111\",\"000\") == \"Not Possible\"\n    assert candidate(\"111\",\"110\") == \"Not Possible\"\n",
       "language": "python"
     },
     {
       "id": 397,
-      "input": "Write a function to find the median of three specific numbers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the median of three specific numbers.\nYour code should pass this test case: assert median_numbers(25,55,65)==55.0",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(25,55,65)==55.0\n    assert candidate(20,10,30)==20.0\n    assert candidate(15,45,75)==45.0\n",
       "language": "python"
     },
     {
       "id": 815,
-      "input": "Write a function to sort the given array without using any sorting algorithm. the given array consists of only 0, 1, and 2.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to sort the given array without using any sorting algorithm. the given array consists of only 0, 1, and 2.\nYour code should pass this test case: assert sort_by_dnf([1,2,0,1,0,1,2,1,1], 9) == [0, 0, 1, 1, 1, 1, 1, 2, 2]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,0,1,0,1,2,1,1], 9) == [0, 0, 1, 1, 1, 1, 1, 2, 2]\n    assert candidate([1,0,0,1,2,1,2,2,1,0], 10) == [0, 0, 0, 1, 1, 1, 1, 2, 2, 2]\n    assert candidate([2,2,1,0,0,0,1,1,2,1], 10) == [0, 0, 0, 1, 1, 1, 1, 2, 2, 2]\n",
       "language": "python"
     },
     {
       "id": 878,
-      "input": "Write a function to check if the given tuple contains only k elements.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check if the given tuple contains only k elements.\nYour code should pass this test case: assert check_tuples((3, 5, 6, 5, 3, 6),[3, 6, 5]) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((3, 5, 6, 5, 3, 6),[3, 6, 5]) == True\n    assert candidate((4, 5, 6, 4, 6, 5),[4, 5, 6]) == True\n    assert candidate((9, 8, 7, 6, 8, 9),[9, 8, 1]) == False\n",
       "language": "python"
     },
     {
       "id": 972,
-      "input": "Write a function to concatenate the given two tuples to a nested tuple.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to concatenate the given two tuples to a nested tuple.\nYour code should pass this test case: assert concatenate_nested((3, 4), (5, 6)) == (3, 4, 5, 6)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((3, 4), (5, 6)) == (3, 4, 5, 6)\n    assert candidate((1, 2), (3, 4)) == (1, 2, 3, 4)\n    assert candidate((4, 5), (6, 8)) == (4, 5, 6, 8)\n",
       "language": "python"
     },
     {
       "id": 606,
-      "input": "Write a function to convert degrees to radians.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to convert degrees to radians.\nYour code should pass this test case: assert radian_degree(90)==1.5707963267948966",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(90)==1.5707963267948966\n    assert candidate(60)==1.0471975511965976\n    assert candidate(120)==2.0943951023931953\n",
       "language": "python"
     },
     {
       "id": 716,
-      "input": "Write a function to find the perimeter of a rombus.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the perimeter of a rombus.\nYour code should pass this test case: assert rombus_perimeter(10)==40",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10)==40\n    assert candidate(5)==20\n    assert candidate(4)==16\n",
       "language": "python"
     },
     {
       "id": 168,
-      "input": "Write a python function to find the frequency of a number in a given array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the frequency of a number in a given array.\nYour code should pass this test case: assert frequency([1,2,3],4) == 0",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,3],4) == 0\n    assert candidate([1,2,2,3,3,3,4],3) == 3\n    assert candidate([0,1,2,3,1,2],1) == 2\n",
       "language": "python"
     },
     {
       "id": 196,
-      "input": "Write a function to remove all the tuples with length k.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to remove all the tuples with length k.\nYour code should pass this test case: assert remove_tuples([(4, 5), (4, ), (8, 6, 7), (1, ), (3, 4, 6, 7)] , 1) == [(4, 5), (8, 6, 7), (3, 4, 6, 7)]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([(4, 5), (4, ), (8, 6, 7), (1, ), (3, 4, 6, 7)] , 1) == [(4, 5), (8, 6, 7), (3, 4, 6, 7)]\n    assert candidate([(4, 5), (4,5), (6, 7), (1, 2, 3), (3, 4, 6, 7)] ,2) == [(1, 2, 3), (3, 4, 6, 7)]\n    assert candidate([(1, 4, 4), (4, 3), (8, 6, 7), (1, ), (3, 6, 7)] , 3) == [(4, 3), (1,)]\n",
       "language": "python"
     },
     {
       "id": 96,
-      "input": "Write a python function to find the number of divisors of a given integer.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the number of divisors of a given integer.\nYour code should pass this test case: assert divisor(15) == 4 ",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(15) == 4 \n    assert candidate(12) == 6\n    assert candidate(9) == 3\n",
       "language": "python"
     },
     {
       "id": 578,
-      "input": "Write a function to interleave lists of the same length.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to interleave lists of the same length.\nYour code should pass this test case: assert interleave_lists([1,2,3,4,5,6,7],[10,20,30,40,50,60,70],[100,200,300,400,500,600,700])==[1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,3,4,5,6,7],[10,20,30,40,50,60,70],[100,200,300,400,500,600,700])==[1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 40, 400, 5, 50, 500, 6, 60, 600, 7, 70, 700]\n    assert candidate([10,20],[15,2],[5,10])==[10,15,5,20,2,10]\n    assert candidate([11,44], [10,15], [20,5])==[11,10,20,44,15,5]\n",
       "language": "python"
     },
     {
       "id": 560,
-      "input": "Write a function to find the union of elements of the given tuples.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the union of elements of the given tuples.\nYour code should pass this test case: assert union_elements((3, 4, 5, 6),(5, 7, 4, 10) ) == (3, 4, 5, 6, 7, 10)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((3, 4, 5, 6),(5, 7, 4, 10) ) == (3, 4, 5, 6, 7, 10)\n    assert candidate((1, 2, 3, 4),(3, 4, 5, 6) ) == (1, 2, 3, 4, 5, 6)\n    assert candidate((11, 12, 13, 14),(13, 15, 16, 17) ) == (11, 12, 13, 14, 15, 16, 17)\n",
       "language": "python"
     },
     {
       "id": 852,
-      "input": "Write a python function to remove negative numbers from a list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to remove negative numbers from a list.\nYour code should pass this test case: assert remove_negs([1,-2,3,-4]) == [1,3]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,-2,3,-4]) == [1,3]\n    assert candidate([1,2,3,-4]) == [1,2,3]\n    assert candidate([4,5,-6,7,-8]) == [4,5,7]\n",
       "language": "python"
     },
     {
       "id": 8,
-      "input": "Write a function to find squares of individual elements in a list using lambda function.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find squares of individual elements in a list using lambda function.\nYour code should pass this test case: assert square_nums([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])==[1, 4, 9, 16, 25, 36, 49, 64, 81, 100]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])==[1, 4, 9, 16, 25, 36, 49, 64, 81, 100]\n    assert candidate([10,20,30])==([100,400,900])\n    assert candidate([12,15])==([144,225])\n",
       "language": "python"
     },
     {
       "id": 62,
-      "input": "Write a python function to find smallest number in a list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find smallest number in a list.\nYour code should pass this test case: assert smallest_num([10, 20, 1, 45, 99]) == 1",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([10, 20, 1, 45, 99]) == 1\n    assert candidate([1, 2, 3]) == 1\n    assert candidate([45, 46, 50, 60]) == 45\n",
       "language": "python"
     },
     {
       "id": 330,
-      "input": "Write a function to find all three, four, five characters long words in the given string by using regex.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find all three, four, five characters long words in the given string by using regex.\nYour code should pass this test case: assert find_char('For the four consumer complaints contact manager AKR reddy') == ['For', 'the', 'four', 'AKR', 'reddy']",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('For the four consumer complaints contact manager AKR reddy') == ['For', 'the', 'four', 'AKR', 'reddy']\n    assert candidate('Certain service are subject to change MSR') == ['are', 'MSR']\n    assert candidate('Third party legal desclaimers') == ['Third', 'party', 'legal']\n",
       "language": "python"
     },
     {
       "id": 194,
-      "input": "Write a python function to convert octal number to decimal number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to convert octal number to decimal number.\nYour code should pass this test case: assert octal_To_Decimal(25) == 21",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(25) == 21\n    assert candidate(30) == 24\n    assert candidate(40) == 32\n",
       "language": "python"
     },
     {
       "id": 71,
-      "input": "Write a function to sort a list of elements using comb sort.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to sort a list of elements using comb sort.\nYour code should pass this test case: assert comb_sort([5, 15, 37, 25, 79]) == [5, 15, 25, 37, 79]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([5, 15, 37, 25, 79]) == [5, 15, 25, 37, 79]\n    assert candidate([41, 32, 15, 19, 22]) == [15, 19, 22, 32, 41]\n    assert candidate([99, 15, 13, 47]) == [13, 15, 47, 99]\n",
       "language": "python"
     },
     {
       "id": 509,
-      "input": "Write a python function to find the average of odd numbers till a given odd number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the average of odd numbers till a given odd number.\nYour code should pass this test case: assert average_Odd(9) == 5",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(9) == 5\n    assert candidate(5) == 3\n    assert candidate(11) == 6\n",
       "language": "python"
     },
     {
       "id": 859,
-      "input": "Write a function to generate all sublists of a given list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to generate all sublists of a given list.\nYour code should pass this test case: assert sub_lists([10, 20, 30, 40])==[[], [10], [20], [30], [40], [10, 20], [10, 30], [10, 40], [20, 30], [20, 40], [30, 40], [10, 20, 30], [10, 20, 40], [10, 30, 40], [20, 30, 40], [10, 20, 30, 40]]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([10, 20, 30, 40])==[[], [10], [20], [30], [40], [10, 20], [10, 30], [10, 40], [20, 30], [20, 40], [30, 40], [10, 20, 30], [10, 20, 40], [10, 30, 40], [20, 30, 40], [10, 20, 30, 40]]\n    assert candidate(['X', 'Y', 'Z'])==[[], ['X'], ['Y'], ['Z'], ['X', 'Y'], ['X', 'Z'], ['Y', 'Z'], ['X', 'Y', 'Z']]\n    assert candidate([1,2,3])==[[],[1],[2],[3],[1,2],[1,3],[2,3],[1,2,3]]\n",
       "language": "python"
     },
     {
       "id": 271,
-      "input": "Write a python function to find the sum of fifth power of first n even natural numbers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the sum of fifth power of first n even natural numbers.\nYour code should pass this test case: assert even_Power_Sum(2) == 1056",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(2) == 1056\n    assert candidate(3) == 8832\n    assert candidate(1) == 32\n",
       "language": "python"
     },
     {
       "id": 319,
-      "input": "Write a function to find all five characters long word in the given string by using regex.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find all five characters long word in the given string by using regex.\nYour code should pass this test case: assert find_long_word('Please move back to strem') == ['strem']",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('Please move back to strem') == ['strem']\n    assert candidate('4K Ultra HD streaming player') == ['Ultra']\n    assert candidate('Streaming Media Player') == ['Media']\n",
       "language": "python"
     },
     {
       "id": 418,
-      "input": "Write a python function to find the sublist having maximum length.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the sublist having maximum length.\nYour code should pass this test case: assert Find_Max([['A'],['A','B'],['A','B','C']]) == ['A','B','C']",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([['A'],['A','B'],['A','B','C']]) == ['A','B','C']\n    assert candidate([[1],[1,2],[1,2,3]]) == [1,2,3]\n    assert candidate([[1,1],[1,2,3],[1,5,6,1]]) == [1,5,6,1]\n",
       "language": "python"
     },
     {
       "id": 236,
-      "input": "Write a python function to count the maximum number of equilateral triangles that can be formed within a given equilateral triangle.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count the maximum number of equilateral triangles that can be formed within a given equilateral triangle.\nYour code should pass this test case: assert No_of_Triangle(4,2) == 7",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(4,2) == 7\n    assert candidate(4,3) == 3\n    assert candidate(1,3) == -1\n",
       "language": "python"
     },
     {
       "id": 435,
-      "input": "Write a python function to find the last digit of a given number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the last digit of a given number.\nYour code should pass this test case: assert last_Digit(123) == 3",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(123) == 3\n    assert candidate(25) == 5\n    assert candidate(30) == 0\n",
       "language": "python"
     },
     {
       "id": 784,
-      "input": "Write a function to find the product of first even and odd number of a given list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the product of first even and odd number of a given list.\nYour code should pass this test case: assert mul_even_odd([1,3,5,7,4,1,6,8])==4",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,3,5,7,4,1,6,8])==4\n    assert candidate([1,2,3,4,5,6,7,8,9,10])==2\n    assert candidate([1,5,7,9,10])==10\n",
       "language": "python"
     },
     {
       "id": 843,
-      "input": "Write a function to find the nth super ugly number from a given prime list of size k using heap queue algorithm.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the nth super ugly number from a given prime list of size k using heap queue algorithm.\nYour code should pass this test case: assert nth_super_ugly_number(12,[2,7,13,19])==32",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(12,[2,7,13,19])==32\n    assert candidate(10,[2,7,13,19])==26\n    assert candidate(100,[2,7,13,19])==5408\n",
       "language": "python"
     },
     {
       "id": 400,
-      "input": "Write a function to extract the frequency of unique tuples in the given list order irrespective.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to extract the frequency of unique tuples in the given list order irrespective.\nYour code should pass this test case: assert extract_freq([(3, 4), (1, 2), (4, 3), (5, 6)] ) == 3",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([(3, 4), (1, 2), (4, 3), (5, 6)] ) == 3\n    assert candidate([(4, 15), (2, 3), (5, 4), (6, 7)] ) == 4\n    assert candidate([(5, 16), (2, 3), (6, 5), (6, 9)] ) == 4\n",
       "language": "python"
     },
     {
       "id": 593,
-      "input": "Write a function to remove leading zeroes from an ip address.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to remove leading zeroes from an ip address.\nYour code should pass this test case: assert removezero_ip(\"216.08.094.196\")==('216.8.94.196') ",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"216.08.094.196\")==('216.8.94.196') \n    assert candidate(\"12.01.024\")==('12.1.24') \n    assert candidate(\"216.08.094.0196\")==('216.8.94.196') \n",
       "language": "python"
     },
     {
       "id": 740,
-      "input": "Write a function to convert the given tuple to a key-value dictionary using adjacent elements.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to convert the given tuple to a key-value dictionary using adjacent elements.\nYour code should pass this test case: assert tuple_to_dict((1, 5, 7, 10, 13, 5)) == {1: 5, 7: 10, 13: 5}",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((1, 5, 7, 10, 13, 5)) == {1: 5, 7: 10, 13: 5}\n    assert candidate((1, 2, 3, 4, 5, 6)) == {1: 2, 3: 4, 5: 6}\n    assert candidate((7, 8, 9, 10, 11, 12)) == {7: 8, 9: 10, 11: 12}\n",
       "language": "python"
     },
     {
       "id": 230,
-      "input": "Write a function to replace blank spaces with any character in a string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to replace blank spaces with any character in a string.\nYour code should pass this test case: assert replace_blank(\"hello people\",'@')==(\"hello@people\")",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"hello people\",'@')==(\"hello@people\")\n    assert candidate(\"python program language\",'$')==(\"python$program$language\")\n    assert candidate(\"blank space\",\"-\")==(\"blank-space\")\n",
       "language": "python"
     },
     {
       "id": 918,
-      "input": "Write a function to count coin change.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to count coin change.\nYour code should pass this test case: assert coin_change([1, 2, 3],3,4)==4",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 2, 3],3,4)==4\n    assert candidate([4,5,6,7,8,9],6,9)==2\n    assert candidate([4,5,6,7,8,9],6,4)==1\n",
       "language": "python"
     },
     {
       "id": 684,
-      "input": "Write a python function to count occurences of a character in a repeated string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count occurences of a character in a repeated string.\nYour code should pass this test case: assert count_Char(\"abcac\",'a') == 4",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"abcac\",'a') == 4\n    assert candidate(\"abca\",'c') == 2\n    assert candidate(\"aba\",'a') == 7\n",
       "language": "python"
     },
     {
       "id": 685,
-      "input": "Write a python function to find sum of prime numbers between 1 to n.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find sum of prime numbers between 1 to n.\nYour code should pass this test case: assert sum_Of_Primes(10) == 17",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10) == 17\n    assert candidate(20) == 77\n    assert candidate(5) == 10\n",
       "language": "python"
     },
     {
       "id": 238,
-      "input": "Write a python function to count number of non-empty substrings of a given string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count number of non-empty substrings of a given string.\nYour code should pass this test case: assert number_of_substrings(\"abc\") == 6",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"abc\") == 6\n    assert candidate(\"abcd\") == 10\n    assert candidate(\"abcde\") == 15\n",
       "language": "python"
     },
     {
       "id": 966,
-      "input": "Write a function to remove an empty tuple from a list of tuples.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to remove an empty tuple from a list of tuples.\nYour code should pass this test case: assert remove_empty([(), (), ('',), ('a', 'b'), ('a', 'b', 'c'), ('d')])==[('',), ('a', 'b'), ('a', 'b', 'c'), 'd']  ",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([(), (), ('',), ('a', 'b'), ('a', 'b', 'c'), ('d')])==[('',), ('a', 'b'), ('a', 'b', 'c'), 'd']  \n    assert candidate([(), (), ('',), (\"python\"), (\"program\")])==[('',), (\"python\"), (\"program\")]  \n    assert candidate([(), (), ('',), (\"java\")])==[('',),(\"java\") ]  \n",
       "language": "python"
     },
     {
       "id": 365,
-      "input": "Write a python function to count the number of digits of a given number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count the number of digits of a given number.\nYour code should pass this test case: assert count_Digit(12345) == 5",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(12345) == 5\n    assert candidate(11223305) == 8\n    assert candidate(4123459) == 7\n",
       "language": "python"
     },
     {
       "id": 471,
-      "input": "Write a python function to find remainder of array multiplication divided by n.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find remainder of array multiplication divided by n.\nYour code should pass this test case: assert find_remainder([ 100, 10, 5, 25, 35, 14 ],6,11) ==9",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([ 100, 10, 5, 25, 35, 14 ],6,11) ==9\n    assert candidate([1,1,1],3,1) == 0\n    assert candidate([1,2,1],3,2) == 0\n",
       "language": "python"
     },
     {
       "id": 799,
-      "input": "Write a python function to left rotate the bits of a given number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to left rotate the bits of a given number.\nYour code should pass this test case: assert left_Rotate(16,2) == 64",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(16,2) == 64\n    assert candidate(10,2) == 40\n    assert candidate(99,3) == 792\n",
       "language": "python"
     },
     {
       "id": 147,
-      "input": "Write a function to find the maximum total path sum in the given triangle.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the maximum total path sum in the given triangle.\nYour code should pass this test case: assert max_path_sum([[1, 0, 0], [4, 8, 0], [1, 5, 3]], 2, 2) == 14",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[1, 0, 0], [4, 8, 0], [1, 5, 3]], 2, 2) == 14\n    assert candidate([[13, 0, 0], [7, 4, 0], [2, 4, 6]], 2, 2) == 24 \n    assert candidate([[2, 0, 0], [11, 18, 0], [21, 25, 33]], 2, 2) == 53\n",
       "language": "python"
     },
     {
       "id": 753,
-      "input": "Write a function to find minimum k records from tuple list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find minimum k records from tuple list.\nYour code should pass this test case: assert min_k([('Manjeet', 10), ('Akshat', 4), ('Akash', 2), ('Nikhil', 8)], 2) == [('Akash', 2), ('Akshat', 4)]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([('Manjeet', 10), ('Akshat', 4), ('Akash', 2), ('Nikhil', 8)], 2) == [('Akash', 2), ('Akshat', 4)]\n    assert candidate([('Sanjeev', 11), ('Angat', 5), ('Akash', 3), ('Nepin', 9)], 3) == [('Akash', 3), ('Angat', 5), ('Nepin', 9)]\n    assert candidate([('tanmay', 14), ('Amer', 11), ('Ayesha', 9), ('SKD', 16)], 1) == [('Ayesha', 9)]\n",
       "language": "python"
     },
     {
       "id": 811,
-      "input": "Write a function to check if two lists of tuples are identical or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check if two lists of tuples are identical or not.\nYour code should pass this test case: assert check_identical([(10, 4), (2, 5)], [(10, 4), (2, 5)]) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([(10, 4), (2, 5)], [(10, 4), (2, 5)]) == True\n    assert candidate([(1, 2), (3, 7)], [(12, 14), (12, 45)]) == False\n    assert candidate([(2, 14), (12, 25)], [(2, 14), (12, 25)]) == True\n",
       "language": "python"
     },
     {
       "id": 788,
-      "input": "Write a function to create a new tuple from the given string and list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to create a new tuple from the given string and list.\nYour code should pass this test case: assert new_tuple([\"WEB\", \"is\"], \"best\") == ('WEB', 'is', 'best')",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([\"WEB\", \"is\"], \"best\") == ('WEB', 'is', 'best')\n    assert candidate([\"We\", \"are\"], \"Developers\") == ('We', 'are', 'Developers')\n    assert candidate([\"Part\", \"is\"], \"Wrong\") == ('Part', 'is', 'Wrong')\n",
       "language": "python"
     },
     {
       "id": 447,
-      "input": "Write a function to find cubes of individual elements in a list using lambda function.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find cubes of individual elements in a list using lambda function.\nYour code should pass this test case: assert cube_nums([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])==[1, 8, 27, 64, 125, 216, 343, 512, 729, 1000]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])==[1, 8, 27, 64, 125, 216, 343, 512, 729, 1000]\n    assert candidate([10,20,30])==([1000, 8000, 27000])\n    assert candidate([12,15])==([1728, 3375])\n",
       "language": "python"
     },
     {
       "id": 241,
-      "input": "Write a function to generate a 3d array having each element as '*'.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to generate a 3d array having each element as '*'.\nYour code should pass this test case: assert array_3d(6,4,3)==[[['*', '*', '*', '*', '*', '*'], ['*', '*', '*', '*', '*', '*'], ['*', '*', '*', '*', '*', '*'], ['*', '*', '*', '*', '*', '*']], [['*', '*', '*', '*', '*', '*'], ['*', '*', '*', '*', '*', '*'], ['*', '*', '*', '*', '*', '*'], ['*', '*', '*', '*', '*', '*']], [['*', '*', '*', '*', '*', '*'], ['*', '*', '*', '*', '*', '*'], ['*', '*', '*', '*', '*', '*'], ['*', '*', '*', '*', '*', '*']]]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(6,4,3)==[[['*', '*', '*', '*', '*', '*'], ['*', '*', '*', '*', '*', '*'], ['*', '*', '*', '*', '*', '*'], ['*', '*', '*', '*', '*', '*']], [['*', '*', '*', '*', '*', '*'], ['*', '*', '*', '*', '*', '*'], ['*', '*', '*', '*', '*', '*'], ['*', '*', '*', '*', '*', '*']], [['*', '*', '*', '*', '*', '*'], ['*', '*', '*', '*', '*', '*'], ['*', '*', '*', '*', '*', '*'], ['*', '*', '*', '*', '*', '*']]]\n    assert candidate(5,3,4)==[[['*', '*', '*', '*', '*'], ['*', '*', '*', '*','*'], ['*', '*', '*', '*', '*']], [['*', '*', '*', '*', '*'],['*', '*', '*', '*', '*'], ['*', '*', '*', '*', '*']], [['*', '*', '*', '*', '*'], ['*', '*', '*', '*', '*'], ['*', '*', '*', '*', '*']], [['*', '*', '*', '*', '*'], ['*', '*', '*', '*', '*'], ['*', '*', '*', '*', '*']]]\n    assert candidate(1,2,3)==[[['*'],['*']],[['*'],['*']],[['*'],['*']]]\n",
       "language": "python"
     },
     {
       "id": 212,
-      "input": "Write a python function to find the sum of fourth power of n natural numbers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the sum of fourth power of n natural numbers.\nYour code should pass this test case: assert fourth_Power_Sum(2) == 17",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(2) == 17\n    assert candidate(4) == 354\n    assert candidate(6) == 2275\n",
       "language": "python"
     },
     {
       "id": 66,
-      "input": "Write a python function to count positive numbers in a list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count positive numbers in a list.\nYour code should pass this test case: assert pos_count([1,-2,3,-4]) == 2",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,-2,3,-4]) == 2\n    assert candidate([3,4,5,-1]) == 3\n    assert candidate([1,2,3,4]) == 4\n",
       "language": "python"
     },
     {
       "id": 85,
-      "input": "Write a function to find the surface area of a sphere.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the surface area of a sphere.\nYour code should pass this test case: assert surfacearea_sphere(10)==1256.6370614359173",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10)==1256.6370614359173\n    assert candidate(15)==2827.4333882308138\n    assert candidate(20)==5026.548245743669\n",
       "language": "python"
     },
     {
       "id": 470,
-      "input": "Write a function to find the pairwise addition of the elements of the given tuples.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the pairwise addition of the elements of the given tuples.\nYour code should pass this test case: assert add_pairwise((1, 5, 7, 8, 10)) == (6, 12, 15, 18)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((1, 5, 7, 8, 10)) == (6, 12, 15, 18)\n    assert candidate((2, 6, 8, 9, 11)) == (8, 14, 17, 20)\n    assert candidate((3, 7, 9, 10, 12)) == (10, 16, 19, 22)\n",
       "language": "python"
     },
     {
       "id": 292,
-      "input": "Write a python function to find quotient of two numbers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find quotient of two numbers.\nYour code should pass this test case: assert find(10,3) == 3",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10,3) == 3\n    assert candidate(4,2) == 2\n    assert candidate(20,5) == 4\n",
       "language": "python"
     },
     {
       "id": 754,
-      "input": "Write a function to find common index elements from three lists.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find common index elements from three lists.\nYour code should pass this test case: assert extract_index_list([1, 1, 3, 4, 5, 6, 7],[0, 1, 2, 3, 4, 5, 7],[0, 1, 2, 3, 4, 5, 7])==[1, 7]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 1, 3, 4, 5, 6, 7],[0, 1, 2, 3, 4, 5, 7],[0, 1, 2, 3, 4, 5, 7])==[1, 7]\n    assert candidate([1, 1, 3, 4, 5, 6, 7],[0, 1, 2, 3, 4, 6, 5],[0, 1, 2, 3, 4, 6, 7])==[1, 6]\n    assert candidate([1, 1, 3, 4, 6, 5, 6],[0, 1, 2, 3, 4, 5, 7],[0, 1, 2, 3, 4, 5, 7])==[1, 5]\n",
       "language": "python"
     },
     {
       "id": 464,
-      "input": "Write a function to check if all values are same in a dictionary.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check if all values are same in a dictionary.\nYour code should pass this test case: assert check_value({'Cierra Vega': 12, 'Alden Cantrell': 12, 'Kierra Gentry': 12, 'Pierre Cox': 12},10)==False",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate({'Cierra Vega': 12, 'Alden Cantrell': 12, 'Kierra Gentry': 12, 'Pierre Cox': 12},10)==False\n    assert candidate({'Cierra Vega': 12, 'Alden Cantrell': 12, 'Kierra Gentry': 12, 'Pierre Cox': 12},12)==True\n    assert candidate({'Cierra Vega': 12, 'Alden Cantrell': 12, 'Kierra Gentry': 12, 'Pierre Cox': 12},5)==False\n",
       "language": "python"
     },
     {
       "id": 490,
-      "input": "Write a function to extract all the pairs which are symmetric in the given tuple list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to extract all the pairs which are symmetric in the given tuple list.\nYour code should pass this test case: assert extract_symmetric([(6, 7), (2, 3), (7, 6), (9, 8), (10, 2), (8, 9)] ) == {(8, 9), (6, 7)}",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([(6, 7), (2, 3), (7, 6), (9, 8), (10, 2), (8, 9)] ) == {(8, 9), (6, 7)}\n    assert candidate([(7, 8), (3, 4), (8, 7), (10, 9), (11, 3), (9, 10)] ) == {(9, 10), (7, 8)}\n    assert candidate([(8, 9), (4, 5), (9, 8), (11, 10), (12, 4), (10, 11)] ) == {(8, 9), (10, 11)}\n",
       "language": "python"
     },
     {
       "id": 868,
-      "input": "Write a python function to find the length of the last word in a given string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the length of the last word in a given string.\nYour code should pass this test case: assert length_Of_Last_Word(\"python language\") == 8",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"python language\") == 8\n    assert candidate(\"PHP\") == 3\n    assert candidate(\"\") == 0\n",
       "language": "python"
     },
     {
       "id": 576,
-      "input": "Write a python function to check whether an array is subarray of another or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether an array is subarray of another or not.\nYour code should pass this test case: assert is_Sub_Array([1,4,3,5],[1,2],4,2) == False",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,4,3,5],[1,2],4,2) == False\n    assert candidate([1,2,1],[1,2,1],3,3) == True\n    assert candidate([1,0,2,2],[2,2,0],4,3) ==False\n",
       "language": "python"
     },
     {
       "id": 802,
-      "input": "Write a python function to count the number of rotations required to generate a sorted array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count the number of rotations required to generate a sorted array.\nYour code should pass this test case: assert count_Rotation([3,2,1],3) == 1",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([3,2,1],3) == 1\n    assert candidate([4,5,1,2,3],5) == 2\n    assert candidate([7,8,9,1,2,3],6) == 3\n",
       "language": "python"
     },
     {
       "id": 655,
-      "input": "Write a python function to find the sum of fifth power of n natural numbers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the sum of fifth power of n natural numbers.\nYour code should pass this test case: assert fifth_Power_Sum(2) == 33",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(2) == 33\n    assert candidate(4) == 1300\n    assert candidate(3) == 276\n",
       "language": "python"
     },
     {
       "id": 337,
-      "input": "Write a function that matches a word at the end of a string, with optional punctuation.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function that matches a word at the end of a string, with optional punctuation.\nYour code should pass this test case: assert text_match_word(\"python.\")==('Found a match!')",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"python.\")==('Found a match!')\n    assert candidate(\"python.\")==('Found a match!')\n    assert candidate(\"  lang  .\")==('Not matched!')\n",
       "language": "python"
     },
     {
       "id": 167,
-      "input": "Write a python function to find smallest power of 2 greater than or equal to n.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find smallest power of 2 greater than or equal to n.\nYour code should pass this test case: assert next_Power_Of_2(0) == 1",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(0) == 1\n    assert candidate(5) == 8\n    assert candidate(17) == 32\n",
       "language": "python"
     },
     {
       "id": 328,
-      "input": "Write a function to rotate a given list by specified number of items to the left direction.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to rotate a given list by specified number of items to the left direction.\nYour code should pass this test case: assert rotate_left([1, 2, 3, 4, 5, 6, 7, 8, 9, 10],3,4)==[4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10],3,4)==[4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4]\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10],2,2)==[3, 4, 5, 6, 7, 8, 9, 10, 1, 2]\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10],5,2)==[6, 7, 8, 9, 10, 1, 2]\n",
       "language": "python"
     },
     {
       "id": 476,
-      "input": "Write a python function to find the sum of the largest and smallest value in a given array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the sum of the largest and smallest value in a given array.\nYour code should pass this test case: assert big_sum([1,2,3]) == 4",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,3]) == 4\n    assert candidate([-1,2,3,4]) == 3\n    assert candidate([2,3,6]) == 8\n",
       "language": "python"
     },
     {
       "id": 681,
-      "input": "Write a python function to find the smallest prime divisor of a number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the smallest prime divisor of a number.\nYour code should pass this test case: assert smallest_Divisor(10) == 2",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10) == 2\n    assert candidate(25) == 5\n    assert candidate(31) == 31\n",
       "language": "python"
     },
     {
       "id": 805,
-      "input": "Write a function to find the list in a list of lists whose sum of elements is the highest.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the list in a list of lists whose sum of elements is the highest.\nYour code should pass this test case: assert max_sum_list([[1,2,3], [4,5,6], [10,11,12], [7,8,9]])==[10, 11, 12] ",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[1,2,3], [4,5,6], [10,11,12], [7,8,9]])==[10, 11, 12] \n    assert candidate([[3,2,1], [6,5,4], [12,11,10]])==[12,11,10] \n    assert candidate([[2,3,1]])==[2,3,1] \n",
       "language": "python"
     },
     {
       "id": 379,
-      "input": "Write a function to find the surface area of a cuboid.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the surface area of a cuboid.\nYour code should pass this test case: assert surfacearea_cuboid(1,2,3)==22",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(1,2,3)==22\n    assert candidate(5,7,9)==286\n    assert candidate(10,15,21)==1350\n",
       "language": "python"
     },
     {
       "id": 111,
-      "input": "Write a function to find common elements in given nested lists. * list item * list item * list item * list item",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find common elements in given nested lists. * list item * list item * list item * list item\nYour code should pass this test case: assert common_in_nested_lists([[12, 18, 23, 25, 45], [7, 12, 18, 24, 28], [1, 5, 8, 12, 15, 16, 18]])==[18, 12]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[12, 18, 23, 25, 45], [7, 12, 18, 24, 28], [1, 5, 8, 12, 15, 16, 18]])==[18, 12]\n    assert candidate([[12, 5, 23, 25, 45], [7, 11, 5, 23, 28], [1, 5, 8, 18, 23, 16]])==[5,23]\n    assert candidate([[2, 3,4, 1], [4, 5], [6,4, 8],[4, 5], [6, 8,4]])==[4]\n",
       "language": "python"
     },
     {
       "id": 648,
-      "input": "Write a function to exchange the position of every n-th value with (n+1)th value and (n+1)th value with n-th value in a given list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to exchange the position of every n-th value with (n+1)th value and (n+1)th value with n-th value in a given list.\nYour code should pass this test case: assert exchange_elements([0,1,2,3,4,5])==[1, 0, 3, 2, 5, 4] ",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([0,1,2,3,4,5])==[1, 0, 3, 2, 5, 4] \n    assert candidate([5,6,7,8,9,10])==[6,5,8,7,10,9] \n    assert candidate([25,35,45,55,75,95])==[35,25,55,45,95,75] \n",
       "language": "python"
     },
     {
       "id": 910,
-      "input": "Write a function to validate a gregorian date.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to validate a gregorian date.\nYour code should pass this test case: assert check_date(11,11,2002)==True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(11,11,2002)==True\n    assert candidate(13,11,2002)==False\n    assert candidate('11','11','2002')==True\n",
       "language": "python"
     },
     {
       "id": 590,
-      "input": "Write a function to convert polar coordinates to rectangular coordinates.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to convert polar coordinates to rectangular coordinates.\nYour code should pass this test case: assert polar_rect(3,4)==((5.0, 0.9272952180016122), (-2+2.4492935982947064e-16j))",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(3,4)==((5.0, 0.9272952180016122), (-2+2.4492935982947064e-16j))\n    assert candidate(4,7)==((8.06225774829855, 1.0516502125483738), (-2+2.4492935982947064e-16j))\n    assert candidate(15,17)==((22.67156809750927, 0.8478169733934057), (-2+2.4492935982947064e-16j))\n",
       "language": "python"
     },
     {
       "id": 526,
-      "input": "Write a python function to capitalize first and last letters of each word of a given string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to capitalize first and last letters of each word of a given string.\nYour code should pass this test case: assert capitalize_first_last_letters(\"python\") == \"PythoN\"",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"python\") == \"PythoN\"\n    assert candidate(\"bigdata\") == \"BigdatA\"\n    assert candidate(\"Hadoop\") == \"HadooP\"\n",
       "language": "python"
     },
     {
       "id": 261,
-      "input": "Write a function to perform mathematical division operation across the given tuples.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to perform mathematical division operation across the given tuples.\nYour code should pass this test case: assert division_elements((10, 4, 6, 9),(5, 2, 3, 3)) == (2, 2, 2, 3)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((10, 4, 6, 9),(5, 2, 3, 3)) == (2, 2, 2, 3)\n    assert candidate((12, 6, 8, 16),(6, 3, 4, 4)) == (2, 2, 2, 4)\n    assert candidate((20, 14, 36, 18),(5, 7, 6, 9)) == (4, 2, 6, 2)\n",
       "language": "python"
     },
     {
       "id": 333,
-      "input": "Write a python function to sort a list according to the second element in sublist.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to sort a list according to the second element in sublist.\nYour code should pass this test case: assert Sort([['a', 10], ['b', 5], ['c', 20], ['d', 15]]) == [['b', 5], ['a', 10], ['d', 15], ['c', 20]]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([['a', 10], ['b', 5], ['c', 20], ['d', 15]]) == [['b', 5], ['a', 10], ['d', 15], ['c', 20]]\n    assert candidate([['452', 10], ['256', 5], ['100', 20], ['135', 15]]) == [['256', 5], ['452', 10], ['135', 15], ['100', 20]]\n    assert candidate([['rishi', 10], ['akhil', 5], ['ramya', 20], ['gaur', 15]]) == [['akhil', 5], ['rishi', 10], ['gaur', 15], ['ramya', 20]]\n",
       "language": "python"
     },
     {
       "id": 301,
-      "input": "Write a function to find the depth of a dictionary.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the depth of a dictionary.\nYour code should pass this test case: assert dict_depth({'a':1, 'b': {'c': {'d': {}}}})==4",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate({'a':1, 'b': {'c': {'d': {}}}})==4\n    assert candidate({'a':1, 'b': {'c':'python'}})==2\n    assert candidate({1: 'Sun', 2: {3: {4:'Mon'}}})==3\n",
       "language": "python"
     },
     {
       "id": 410,
-      "input": "Write a function to find the minimum value in a given heterogeneous list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the minimum value in a given heterogeneous list.\nYour code should pass this test case: assert min_val(['Python', 3, 2, 4, 5, 'version'])==2",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(['Python', 3, 2, 4, 5, 'version'])==2\n    assert candidate(['Python', 15, 20, 25])==15\n    assert candidate(['Python', 30, 20, 40, 50, 'version'])==20\n",
       "language": "python"
     },
     {
       "id": 15,
-      "input": "Write a function to split a string at lowercase letters.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to split a string at lowercase letters.\nYour code should pass this test case: assert split_lowerstring(\"AbCd\")==['bC','d']",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"AbCd\")==['bC','d']\n    assert candidate(\"Python\")==['y', 't', 'h', 'o', 'n']\n    assert candidate(\"Programming\")==['r', 'o', 'g', 'r', 'a', 'm', 'm', 'i', 'n', 'g']\n",
       "language": "python"
     },
     {
       "id": 486,
-      "input": "Write a function to compute binomial probability for the given number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to compute binomial probability for the given number.\nYour code should pass this test case: assert binomial_probability(10, 5, 1.0/3) == 0.13656454808718185",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10, 5, 1.0/3) == 0.13656454808718185\n    assert candidate(11, 6, 2.0/4) == 0.2255859375\n    assert candidate(12, 7, 3.0/5) == 0.227030335488\n",
       "language": "python"
     },
     {
       "id": 824,
-      "input": "Write a python function to remove even numbers from a given list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to remove even numbers from a given list.\nYour code should pass this test case: assert remove_even([1,3,5,2]) == [1,3,5]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,3,5,2]) == [1,3,5]\n    assert candidate([5,6,7]) == [5,7]\n    assert candidate([1,2,3,4]) == [1,3]\n",
       "language": "python"
     },
     {
       "id": 174,
-      "input": "Write a function to group a sequence of key-value pairs into a dictionary of lists.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to group a sequence of key-value pairs into a dictionary of lists.\nYour code should pass this test case: assert group_keyvalue([('yellow', 1), ('blue', 2), ('yellow', 3), ('blue', 4), ('red', 1)])=={'yellow': [1, 3], 'blue': [2, 4], 'red': [1]}",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([('yellow', 1), ('blue', 2), ('yellow', 3), ('blue', 4), ('red', 1)])=={'yellow': [1, 3], 'blue': [2, 4], 'red': [1]}\n    assert candidate([('python', 1), ('python', 2), ('python', 3), ('python', 4), ('python', 5)])=={'python': [1,2,3,4,5]}\n    assert candidate([('yellow',100), ('blue', 200), ('yellow', 300), ('blue', 400), ('red', 100)])=={'yellow': [100, 300], 'blue': [200, 400], 'red': [100]}\n",
       "language": "python"
     },
     {
       "id": 481,
-      "input": "Write a function to determine if there is a subset of the given set with sum equal to the given sum.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to determine if there is a subset of the given set with sum equal to the given sum.\nYour code should pass this test case: assert is_subset_sum([3, 34, 4, 12, 5, 2], 6, 9) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([3, 34, 4, 12, 5, 2], 6, 9) == True\n    assert candidate([3, 34, 4, 12, 5, 2], 6, 30) == False\n    assert candidate([3, 34, 4, 12, 5, 2], 6, 15) == True\n",
       "language": "python"
     },
     {
       "id": 259,
-      "input": "Write a function to maximize the given two tuples.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to maximize the given two tuples.\nYour code should pass this test case: assert maximize_elements(((1, 3), (4, 5), (2, 9), (1, 10)), ((6, 7), (3, 9), (1, 1), (7, 3))) == ((6, 7), (4, 9), (2, 9), (7, 10))",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(((1, 3), (4, 5), (2, 9), (1, 10)), ((6, 7), (3, 9), (1, 1), (7, 3))) == ((6, 7), (4, 9), (2, 9), (7, 10))\n    assert candidate(((2, 4), (5, 6), (3, 10), (2, 11)), ((7, 8), (4, 10), (2, 2), (8, 4))) == ((7, 8), (5, 10), (3, 10), (8, 11))\n    assert candidate(((3, 5), (6, 7), (4, 11), (3, 12)), ((8, 9), (5, 11), (3, 3), (9, 5))) == ((8, 9), (6, 11), (4, 11), (9, 12))\n",
       "language": "python"
     },
     {
       "id": 478,
-      "input": "Write a function to remove lowercase substrings from a given string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to remove lowercase substrings from a given string.\nYour code should pass this test case: assert remove_lowercase(\"PYTHon\")==('PYTH')",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"PYTHon\")==('PYTH')\n    assert candidate(\"FInD\")==('FID')\n    assert candidate(\"STRinG\")==('STRG')\n",
       "language": "python"
     },
     {
       "id": 78,
-      "input": "Write a python function to find number of integers with odd number of set bits.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find number of integers with odd number of set bits.\nYour code should pass this test case: assert count_With_Odd_SetBits(5) == 3",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(5) == 3\n    assert candidate(10) == 5\n    assert candidate(15) == 8\n",
       "language": "python"
     },
     {
       "id": 217,
-      "input": "Write a python function to find the first repeated character in a given string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the first repeated character in a given string.\nYour code should pass this test case: assert first_Repeated_Char(\"Google\") == \"o\"",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"Google\") == \"o\"\n    assert candidate(\"data\") == \"a\"\n    assert candidate(\"python\") == '\\0'\n",
       "language": "python"
     },
     {
       "id": 16,
-      "input": "Write a function to find sequences of lowercase letters joined with an underscore.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find sequences of lowercase letters joined with an underscore.\nYour code should pass this test case: assert text_lowercase_underscore(\"aab_cbbbc\")==('Found a match!')",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"aab_cbbbc\")==('Found a match!')\n    assert candidate(\"aab_Abbbc\")==('Not matched!')\n    assert candidate(\"Aaab_abbbc\")==('Not matched!')\n    assert candidate(\"aab-cbbbc\")==('Not matched!')\n",
       "language": "python"
     },
     {
       "id": 441,
-      "input": "Write a function to find the surface area of a cube.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the surface area of a cube.\nYour code should pass this test case: assert surfacearea_cube(5)==150",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(5)==150\n    assert candidate(3)==54\n    assert candidate(10)==600\n",
       "language": "python"
     },
     {
       "id": 669,
-      "input": "Write a function to check whether the given ip address is valid or not using regex.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check whether the given ip address is valid or not using regex.\nYour code should pass this test case: assert check_IP(\"192.168.0.1\") == 'Valid IP address'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"192.168.0.1\") == 'Valid IP address'\n    assert candidate(\"110.234.52.124\") == 'Valid IP address'\n    assert candidate(\"366.1.2.2\") == 'Invalid IP address'\n",
       "language": "python"
     },
     {
       "id": 933,
-      "input": "Write a function to convert camel case string to snake case string by using regex.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to convert camel case string to snake case string by using regex.\nYour code should pass this test case: assert camel_to_snake('GoogleAssistant') == 'google_assistant'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('GoogleAssistant') == 'google_assistant'\n    assert candidate('ChromeCast') == 'chrome_cast'\n    assert candidate('QuadCore') == 'quad_core'\n",
       "language": "python"
     },
     {
       "id": 177,
-      "input": "Write a python function to find two distinct numbers such that their lcm lies within the given range.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find two distinct numbers such that their lcm lies within the given range.\nYour code should pass this test case: assert answer(3,8) == (3,6)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(3,8) == (3,6)\n    assert candidate(2,6) == (2,4)\n    assert candidate(1,3) == (1,2)\n",
       "language": "python"
     },
     {
       "id": 188,
-      "input": "Write a python function to check whether the given number can be represented by product of two squares or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether the given number can be represented by product of two squares or not.\nYour code should pass this test case: assert prod_Square(25) == False",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(25) == False\n    assert candidate(30) == False\n    assert candidate(16) == True\n",
       "language": "python"
     },
     {
       "id": 913,
-      "input": "Write a function to check for a number at the end of a string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check for a number at the end of a string.\nYour code should pass this test case: assert end_num('abcdef')==False",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('abcdef')==False\n    assert candidate('abcdef7')==True\n    assert candidate('abc')==False\n",
       "language": "python"
     },
     {
       "id": 429,
-      "input": "Write a function to extract the elementwise and tuples from the given two tuples.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to extract the elementwise and tuples from the given two tuples.\nYour code should pass this test case: assert and_tuples((10, 4, 6, 9), (5, 2, 3, 3)) == (0, 0, 2, 1)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((10, 4, 6, 9), (5, 2, 3, 3)) == (0, 0, 2, 1)\n    assert candidate((1, 2, 3, 4), (5, 6, 7, 8)) == (1, 2, 3, 0)\n    assert candidate((8, 9, 11, 12), (7, 13, 14, 17)) == (0, 9, 10, 0)\n",
       "language": "python"
     },
     {
       "id": 303,
-      "input": "Write a python function to check whether the count of inversion of two types are same or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether the count of inversion of two types are same or not.\nYour code should pass this test case: assert solve([1,0,2],3) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,0,2],3) == True\n    assert candidate([1,2,0],3) == False\n    assert candidate([1,2,1],3) == True\n",
       "language": "python"
     },
     {
       "id": 914,
-      "input": "Write a python function to check whether the given string is made up of two alternating characters or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether the given string is made up of two alternating characters or not.\nYour code should pass this test case: assert is_Two_Alter(\"abab\") == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"abab\") == True\n    assert candidate(\"aaaa\") == False\n    assert candidate(\"xyz\") == False\n",
       "language": "python"
     },
     {
       "id": 110,
-      "input": "Write a function to extract the ranges that are missing from the given list with the given start range and end range values.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to extract the ranges that are missing from the given list with the given start range and end range values.\nYour code should pass this test case: assert extract_missing([(6, 9), (15, 34), (48, 70)], 2, 100) == [(2, 6), (9, 100), (9, 15), (34, 100), (34, 48), (70, 100)]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([(6, 9), (15, 34), (48, 70)], 2, 100) == [(2, 6), (9, 100), (9, 15), (34, 100), (34, 48), (70, 100)]\n    assert candidate([(7, 2), (15, 19), (38, 50)], 5, 60) == [(5, 7), (2, 60), (2, 15), (19, 60), (19, 38), (50, 60)]\n    assert candidate([(7, 2), (15, 19), (38, 50)], 1, 52) == [(1, 7), (2, 52), (2, 15), (19, 52), (19, 38), (50, 52)]\n",
       "language": "python"
     },
     {
       "id": 579,
-      "input": "Write a function to find the dissimilar elements in the given two tuples.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the dissimilar elements in the given two tuples.\nYour code should pass this test case: assert find_dissimilar((3, 4, 5, 6), (5, 7, 4, 10)) == (3, 6, 7, 10)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((3, 4, 5, 6), (5, 7, 4, 10)) == (3, 6, 7, 10)\n    assert candidate((1, 2, 3, 4), (7, 2, 3, 9)) == (1, 4, 7, 9)\n    assert candidate((21, 11, 25, 26), (26, 34, 21, 36)) == (34, 36, 11, 25)\n",
       "language": "python"
     },
     {
       "id": 650,
-      "input": "Write a python function to check whether the given two arrays are equal or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether the given two arrays are equal or not.\nYour code should pass this test case: assert are_Equal([1,2,3],[3,2,1],3,3) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,3],[3,2,1],3,3) == True\n    assert candidate([1,1,1],[2,2,2],3,3) == False\n    assert candidate([8,9],[4,5,6],2,3) == False\n",
       "language": "python"
     },
     {
       "id": 186,
-      "input": "Write a function to search some literals strings in a string by using regex.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to search some literals strings in a string by using regex.\nYour code should pass this test case: assert check_literals('The quick brown fox jumps over the lazy dog.',['fox']) == 'Matched!'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('The quick brown fox jumps over the lazy dog.',['fox']) == 'Matched!'\n    assert candidate('The quick brown fox jumps over the lazy dog.',['horse']) == 'Not Matched!'\n    assert candidate('The quick brown fox jumps over the lazy dog.',['lazy']) == 'Matched!'\n",
       "language": "python"
     },
     {
       "id": 575,
-      "input": "Write a python function to find nth number in a sequence which is not a multiple of a given number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find nth number in a sequence which is not a multiple of a given number.\nYour code should pass this test case: assert count_no(2,3,1,10) == 5",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(2,3,1,10) == 5\n    assert candidate(3,6,4,20) == 11\n    assert candidate(5,10,4,20) == 16\n",
       "language": "python"
     },
     {
       "id": 626,
-      "input": "Write a python function to find the largest triangle that can be inscribed in the semicircle.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the largest triangle that can be inscribed in the semicircle.\nYour code should pass this test case: assert triangle_area(0) == 0",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(0) == 0\n    assert candidate(-1) == -1\n    assert candidate(2) == 4\n",
       "language": "python"
     },
     {
       "id": 719,
-      "input": "Write a function that matches a string that has an a followed by zero or more b's.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function that matches a string that has an a followed by zero or more b's.\nYour code should pass this test case: assert text_match(\"ac\")==('Found a match!')",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"ac\")==('Found a match!')\n    assert candidate(\"dc\")==('Not matched!')\n    assert candidate(\"abba\")==('Found a match!')\n",
       "language": "python"
     },
     {
       "id": 63,
-      "input": "Write a function to find the maximum difference between available pairs in the given tuple list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the maximum difference between available pairs in the given tuple list.\nYour code should pass this test case: assert max_difference([(3, 5), (1, 7), (10, 3), (1, 2)]) == 7",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([(3, 5), (1, 7), (10, 3), (1, 2)]) == 7\n    assert candidate([(4, 6), (2, 17), (9, 13), (11, 12)]) == 15\n    assert candidate([(12, 35), (21, 27), (13, 23), (41, 22)]) == 23\n",
       "language": "python"
     },
     {
       "id": 19,
-      "input": "Write a function to find whether a given array of integers contains any duplicate element.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find whether a given array of integers contains any duplicate element.\nYour code should pass this test case: assert test_duplicate(([1,2,3,4,5]))==False",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(([1,2,3,4,5]))==False\n    assert candidate(([1,2,3,4, 4]))==True\n    assert candidate([1,1,2,2,3,3,4,4,5])==True\n",
       "language": "python"
     },
     {
       "id": 942,
-      "input": "Write a function to check if any list element is present in the given list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check if any list element is present in the given list.\nYour code should pass this test case: assert check_element((4, 5, 7, 9, 3),  [6, 7, 10, 11]) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((4, 5, 7, 9, 3),  [6, 7, 10, 11]) == True\n    assert candidate((1, 2, 3, 4),  [4, 6, 7, 8, 9]) == True\n    assert candidate((3, 2, 1, 4, 5),  [9, 8, 7, 6]) == False\n",
       "language": "python"
     },
     {
       "id": 149,
-      "input": "Write a function to find the longest subsequence such that the difference between adjacents is one for the given array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the longest subsequence such that the difference between adjacents is one for the given array.\nYour code should pass this test case: assert longest_subseq_with_diff_one([1, 2, 3, 4, 5, 3, 2], 7) == 6",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 3, 2], 7) == 6\n    assert candidate([10, 9, 4, 5, 4, 8, 6], 7) == 3\n    assert candidate([1, 2, 3, 2, 3, 7, 2, 1], 8) == 7\n",
       "language": "python"
     },
     {
       "id": 395,
-      "input": "Write a python function to find the first non-repeated character in a given string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the first non-repeated character in a given string.\nYour code should pass this test case: assert first_non_repeating_character(\"abcabc\") == None",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"abcabc\") == None\n    assert candidate(\"abc\") == \"a\"\n    assert candidate(\"ababc\") == \"c\"\n",
       "language": "python"
     },
     {
       "id": 717,
-      "input": "Write a function to calculate the standard deviation.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to calculate the standard deviation.\nYour code should pass this test case: assert sd_calc([4, 2, 5, 8, 6])== 2.23606797749979",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([4, 2, 5, 8, 6])== 2.23606797749979\n    assert candidate([1,2,3,4,5,6,7])==2.160246899469287\n    assert candidate([5,9,10,15,6,4])==4.070217029430577\n",
       "language": "python"
     },
     {
       "id": 396,
-      "input": "Write a function to check whether the given string starts and ends with the same character or not using regex.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check whether the given string starts and ends with the same character or not using regex.\nYour code should pass this test case: assert check_char(\"abba\") == \"Valid\"",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"abba\") == \"Valid\"\n    assert candidate(\"a\") == \"Valid\"\n    assert candidate(\"abcd\") == \"Invalid\"\n",
       "language": "python"
     },
     {
       "id": 431,
-      "input": "Write a function that takes two lists and returns true if they have at least one common element.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function that takes two lists and returns true if they have at least one common element.\nYour code should pass this test case: assert common_element([1,2,3,4,5], [5,6,7,8,9])==True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,3,4,5], [5,6,7,8,9])==True\n    assert candidate([1,2,3,4,5], [6,7,8,9])==None\n    assert candidate(['a','b','c'], ['d','b','e'])==True\n",
       "language": "python"
     },
     {
       "id": 372,
-      "input": "Write a function to sort a given list of elements in ascending order using heap queue algorithm.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to sort a given list of elements in ascending order using heap queue algorithm.\nYour code should pass this test case: assert heap_assending([18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1])==[1, 2, 3, 4, 7, 8, 9, 9, 10, 14, 18]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([18, 14, 10, 9, 8, 7, 9, 3, 2, 4, 1])==[1, 2, 3, 4, 7, 8, 9, 9, 10, 14, 18]\n    assert candidate([25, 35, 22, 85, 14, 65, 75, 25, 58])==[14, 22, 25, 25, 35, 58, 65, 75, 85]\n    assert candidate([1, 3, 5, 7, 9, 2, 4, 6, 8, 0])==[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]\n",
       "language": "python"
     },
     {
       "id": 611,
-      "input": "Write a function to find the maximum of nth column from the given tuple list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the maximum of nth column from the given tuple list.\nYour code should pass this test case: assert max_of_nth([(5, 6, 7), (1, 3, 5), (8, 9, 19)], 2) == 19",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([(5, 6, 7), (1, 3, 5), (8, 9, 19)], 2) == 19\n    assert candidate([(6, 7, 8), (2, 4, 6), (9, 10, 20)], 1) == 10\n    assert candidate([(7, 8, 9), (3, 5, 7), (10, 11, 21)], 1) == 11\n",
       "language": "python"
     },
     {
       "id": 574,
-      "input": "Write a function to find the surface area of a cylinder.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the surface area of a cylinder.\nYour code should pass this test case: assert surfacearea_cylinder(10,5)==942.45",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10,5)==942.45\n    assert candidate(4,5)==226.18800000000002\n    assert candidate(4,10)==351.848\n",
       "language": "python"
     },
     {
       "id": 652,
-      "input": "Write a function to flatten the given tuple matrix into the tuple list with each tuple representing each column.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to flatten the given tuple matrix into the tuple list with each tuple representing each column.\nYour code should pass this test case: assert matrix_to_list([[(4, 5), (7, 8)], [(10, 13), (18, 17)], [(0, 4), (10, 1)]]) == '[(4, 7, 10, 18, 0, 10), (5, 8, 13, 17, 4, 1)]'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[(4, 5), (7, 8)], [(10, 13), (18, 17)], [(0, 4), (10, 1)]]) == '[(4, 7, 10, 18, 0, 10), (5, 8, 13, 17, 4, 1)]'\n    assert candidate([[(5, 6), (8, 9)], [(11, 14), (19, 18)], [(1, 5), (11, 2)]]) == '[(5, 8, 11, 19, 1, 11), (6, 9, 14, 18, 5, 2)]'\n    assert candidate([[(6, 7), (9, 10)], [(12, 15), (20, 21)], [(23, 7), (15, 8)]]) == '[(6, 9, 12, 20, 23, 15), (7, 10, 15, 21, 7, 8)]'\n",
       "language": "python"
     },
     {
       "id": 134,
-      "input": "Write a python function to check whether the last element of given array is even or odd after performing an operation p times.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether the last element of given array is even or odd after performing an operation p times.\nYour code should pass this test case: assert check_last([5,7,10],3,1) == \"ODD\"",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([5,7,10],3,1) == \"ODD\"\n    assert candidate([2,3],2,3) == \"EVEN\"\n    assert candidate([1,2,3],3,1) == \"ODD\"\n",
       "language": "python"
     },
     {
       "id": 958,
-      "input": "Write a function to convert an integer into a roman numeral.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to convert an integer into a roman numeral.\nYour code should pass this test case: assert int_to_roman(1)==(\"I\")",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(1)==(\"I\")\n    assert candidate(50)==(\"L\")\n    assert candidate(4)==(\"IV\")\n",
       "language": "python"
     },
     {
       "id": 671,
-      "input": "Write a python function to set the right most unset bit.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to set the right most unset bit.\nYour code should pass this test case: assert set_Right_most_Unset_Bit(21) == 23",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(21) == 23\n    assert candidate(11) == 15\n    assert candidate(15) == 15\n",
       "language": "python"
     },
     {
       "id": 518,
-      "input": "Write a function to find the square root of a perfect number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the square root of a perfect number.\nYour code should pass this test case: assert sqrt_root(4)==2",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(4)==2\n    assert candidate(16)==4\n    assert candidate(400)==20\n",
       "language": "python"
     },
     {
       "id": 93,
-      "input": "Write a function to calculate the value of 'a' to the power 'b'.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to calculate the value of 'a' to the power 'b'.\nYour code should pass this test case: assert power(3,4) == 81",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(3,4) == 81\n    assert candidate(2,3) == 8\n    assert candidate(5,5) == 3125\n",
       "language": "python"
     },
     {
       "id": 427,
-      "input": "Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format by using regex.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to convert a date of yyyy-mm-dd format to dd-mm-yyyy format by using regex.\nYour code should pass this test case: assert change_date_format(\"2026-01-02\") == '02-01-2026'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"2026-01-02\") == '02-01-2026'\n    assert candidate(\"2020-11-13\") == '13-11-2020'\n    assert candidate(\"2021-04-26\") == '26-04-2021'\n",
       "language": "python"
     },
     {
       "id": 761,
-      "input": "Write a function to caluclate arc length of an angle.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to caluclate arc length of an angle.\nYour code should pass this test case: assert arc_length(9,45)==3.5357142857142856",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(9,45)==3.5357142857142856\n    assert candidate(9,480)==None\n    assert candidate(5,270)==11.785714285714285\n",
       "language": "python"
     },
     {
       "id": 795,
-      "input": "Write a function to find the n - cheap price items from a given dataset using heap queue algorithm.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the n - cheap price items from a given dataset using heap queue algorithm.\nYour code should pass this test case: assert cheap_items([{'name': 'Item-1', 'price': 101.1},{'name': 'Item-2', 'price': 555.22}],1)==[{'name': 'Item-1', 'price': 101.1}]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([{'name': 'Item-1', 'price': 101.1},{'name': 'Item-2', 'price': 555.22}],1)==[{'name': 'Item-1', 'price': 101.1}]\n    assert candidate([{'name': 'Item-1', 'price': 101.1},{'name': 'Item-2', 'price': 555.22}],2)==[{'name': 'Item-1', 'price': 101.1},{'name': 'Item-2', 'price': 555.22}]\n    assert candidate([{'name': 'Item-1', 'price': 101.1},{'name': 'Item-2', 'price': 555.22}, {'name': 'Item-3', 'price': 45.09},{'name': 'Item-4', 'price': 22.75}],1)==[{'name': 'Item-4', 'price': 22.75}]\n",
       "language": "python"
     },
     {
       "id": 158,
-      "input": "Write a python function to find k number of operations required to make all elements equal.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find k number of operations required to make all elements equal.\nYour code should pass this test case: assert min_Ops([2,2,2,2],4,3) == 0",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([2,2,2,2],4,3) == 0\n    assert candidate([4,2,6,8],4,3) == -1\n    assert candidate([21,33,9,45,63],5,6) == 24\n",
       "language": "python"
     },
     {
       "id": 923,
-      "input": "Write a function to find the length of the shortest string that has both str1 and str2 as subsequences.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the length of the shortest string that has both str1 and str2 as subsequences.\nYour code should pass this test case: assert super_seq(\"AGGTAB\", \"GXTXAYB\", 6, 7) == 9",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"AGGTAB\", \"GXTXAYB\", 6, 7) == 9\n    assert candidate(\"feek\", \"eke\", 4, 3) == 5\n    assert candidate(\"PARRT\", \"RTA\", 5, 3) == 6\n",
       "language": "python"
     },
     {
       "id": 732,
-      "input": "Write a function to replace all occurrences of spaces, commas, or dots with a colon.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to replace all occurrences of spaces, commas, or dots with a colon.\nYour code should pass this test case: assert replace_specialchar('Python language, Programming language.')==('Python:language::Programming:language:')",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('Python language, Programming language.')==('Python:language::Programming:language:')\n    assert candidate('a b c,d e f')==('a:b:c:d:e:f')\n    assert candidate('ram reshma,ram rahim')==('ram:reshma:ram:rahim')\n",
       "language": "python"
     },
     {
       "id": 443,
-      "input": "Write a python function to find the largest negative number from the given list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the largest negative number from the given list.\nYour code should pass this test case: assert largest_neg([1,2,3,-4,-6]) == -6",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,3,-4,-6]) == -6\n    assert candidate([1,2,3,-8,-9]) == -9\n    assert candidate([1,2,3,4,-1]) == -1\n",
       "language": "python"
     },
     {
       "id": 694,
-      "input": "Write a function to extract unique values from the given dictionary values.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to extract unique values from the given dictionary values.\nYour code should pass this test case: assert extract_unique({'msm' : [5, 6, 7, 8],'is' : [10, 11, 7, 5],'best' : [6, 12, 10, 8],'for' : [1, 2, 5]} ) == [1, 2, 5, 6, 7, 8, 10, 11, 12]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate({'msm' : [5, 6, 7, 8],'is' : [10, 11, 7, 5],'best' : [6, 12, 10, 8],'for' : [1, 2, 5]} ) == [1, 2, 5, 6, 7, 8, 10, 11, 12]\n    assert candidate({'Built' : [7, 1, 9, 4],'for' : [11, 21, 36, 14, 9],'ISP' : [4, 1, 21, 39, 47],'TV' : [1, 32, 38]} ) == [1, 4, 7, 9, 11, 14, 21, 32, 36, 38, 39, 47]\n    assert candidate({'F' : [11, 13, 14, 17],'A' : [12, 11, 15, 18],'N' : [19, 21, 15, 36],'G' : [37, 36, 35]}) == [11, 12, 13, 14, 15, 17, 18, 19, 21, 35, 36, 37]\n",
       "language": "python"
     },
     {
       "id": 810,
-      "input": "Write a function to iterate over elements repeating each as many times as its count.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to iterate over elements repeating each as many times as its count.\nYour code should pass this test case: assert count_variable(4,2,0,-2)==['p', 'p', 'p', 'p', 'q', 'q'] ",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(4,2,0,-2)==['p', 'p', 'p', 'p', 'q', 'q'] \n    assert candidate(0,1,2,3)==['q', 'r', 'r', 's', 's', 's'] \n    assert candidate(11,15,12,23)==['p', 'p', 'p', 'p', 'p', 'p', 'p', 'p', 'p', 'p', 'p', 'q', 'q', 'q', 'q', 'q', 'q', 'q', 'q', 'q', 'q', 'q', 'q', 'q', 'q', 'q', 'r', 'r', 'r', 'r', 'r', 'r', 'r', 'r', 'r', 'r', 'r', 'r', 's', 's', 's', 's', 's', 's', 's', 's', 's', 's', 's', 's', 's', 's', 's', 's', 's', 's', 's', 's', 's', 's', 's']\n",
       "language": "python"
     },
     {
       "id": 95,
-      "input": "Write a python function to find the minimum length of sublist.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the minimum length of sublist.\nYour code should pass this test case: assert Find_Min_Length([[1],[1,2]]) == 1",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[1],[1,2]]) == 1\n    assert candidate([[1,2],[1,2,3],[1,2,3,4]]) == 2\n    assert candidate([[3,3,3],[4,4,4,4]]) == 3\n",
       "language": "python"
     },
     {
       "id": 731,
-      "input": "Write a function to find the lateral surface area of a cone.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the lateral surface area of a cone.\nYour code should pass this test case: assert lateralsurface_cone(5,12)==204.20352248333654",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(5,12)==204.20352248333654\n    assert candidate(10,15)==566.3586699569488\n    assert candidate(19,17)==1521.8090132193388\n",
       "language": "python"
     },
     {
       "id": 667,
-      "input": "Write a python function to count number of vowels in the string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count number of vowels in the string.\nYour code should pass this test case: assert Check_Vow('corner','AaEeIiOoUu') == 2",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('corner','AaEeIiOoUu') == 2\n    assert candidate('valid','AaEeIiOoUu') == 2\n    assert candidate('true','AaEeIiOoUu') ==2\n",
       "language": "python"
     },
     {
       "id": 142,
-      "input": "Write a function to count the same pair in three given lists.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to count the same pair in three given lists.\nYour code should pass this test case: assert count_samepair([1,2,3,4,5,6,7,8],[2,2,3,1,2,6,7,9],[2,1,3,1,2,6,7,9])==3",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,3,4,5,6,7,8],[2,2,3,1,2,6,7,9],[2,1,3,1,2,6,7,9])==3\n    assert candidate([1,2,3,4,5,6,7,8],[2,2,3,1,2,6,7,8],[2,1,3,1,2,6,7,8])==4\n    assert candidate([1,2,3,4,2,6,7,8],[2,2,3,1,2,6,7,8],[2,1,3,1,2,6,7,8])==5\n",
       "language": "python"
     },
     {
       "id": 86,
-      "input": "Write a function to find nth centered hexagonal number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find nth centered hexagonal number.\nYour code should pass this test case: assert centered_hexagonal_number(10) == 271",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10) == 271\n    assert candidate(2) == 7\n    assert candidate(9) == 217\n",
       "language": "python"
     },
     {
       "id": 100,
-      "input": "Write a function to find the next smallest palindrome of a specified number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the next smallest palindrome of a specified number.\nYour code should pass this test case: assert next_smallest_palindrome(99)==101",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(99)==101\n    assert candidate(1221)==1331\n    assert candidate(120)==121\n",
       "language": "python"
     },
     {
       "id": 175,
-      "input": "Write a function to verify validity of a string of parentheses.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to verify validity of a string of parentheses.\nYour code should pass this test case: assert is_valid_parenthese(\"(){}[]\")==True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"(){}[]\")==True\n    assert candidate(\"()[{)}\")==False\n    assert candidate(\"()\")==True\n",
       "language": "python"
     },
     {
       "id": 29,
-      "input": "Write a python function to find the element occurring odd number of times.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the element occurring odd number of times.\nYour code should pass this test case: assert get_Odd_Occurrence([1,2,3,1,2,3,1],7) == 1",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,3,1,2,3,1],7) == 1\n    assert candidate([1,2,3,2,3,1,3],7) == 3\n    assert candidate([2,3,5,4,5,2,4,3,5,2,4,4,2],13) == 5\n",
       "language": "python"
     },
     {
       "id": 675,
-      "input": "Write a function to add two integers. however, if the sum is between the given range it will return 20.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to add two integers. however, if the sum is between the given range it will return 20.\nYour code should pass this test case: assert sum_nums(2,10,11,20)==20",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(2,10,11,20)==20\n    assert candidate(15,17,1,10)==32\n    assert candidate(10,15,5,30)==20\n",
       "language": "python"
     },
     {
       "id": 833,
-      "input": "Write a function to get dictionary keys as a list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to get dictionary keys as a list.\nYour code should pass this test case: assert get_key({1:'python',2:'java'})==[1,2]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate({1:'python',2:'java'})==[1,2]\n    assert candidate({10:'red',20:'blue',30:'black'})==[10,20,30]\n    assert candidate({27:'language',39:'java',44:'little'})==[27,39,44]\n",
       "language": "python"
     },
     {
       "id": 882,
-      "input": "Write a function to caluclate perimeter of a parallelogram.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to caluclate perimeter of a parallelogram.\nYour code should pass this test case: assert parallelogram_perimeter(10,20)==400",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10,20)==400\n    assert candidate(15,20)==600\n    assert candidate(8,9)==144\n",
       "language": "python"
     },
     {
       "id": 264,
-      "input": "Write a function to calculate a dog's age in dog's years.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to calculate a dog's age in dog's years.\nYour code should pass this test case: assert dog_age(12)==61",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(12)==61\n    assert candidate(15)==73\n    assert candidate(24)==109\n",
       "language": "python"
     },
     {
       "id": 466,
-      "input": "Write a function to find the peak element in the given array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the peak element in the given array.\nYour code should pass this test case: assert find_peak([1, 3, 20, 4, 1, 0], 6) == 2",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 3, 20, 4, 1, 0], 6) == 2\n    assert candidate([2, 3, 4, 5, 6], 5) == 4\n    assert candidate([8, 9, 11, 12, 14, 15], 6) == 5 \n",
       "language": "python"
     },
     {
       "id": 672,
-      "input": "Write a function to find maximum of three numbers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find maximum of three numbers.\nYour code should pass this test case: assert max_of_three(10,20,30)==30",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10,20,30)==30\n    assert candidate(55,47,39)==55\n    assert candidate(10,49,30)==49\n",
       "language": "python"
     },
     {
       "id": 821,
-      "input": "Write a function to merge two dictionaries into a single expression.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to merge two dictionaries into a single expression.\nYour code should pass this test case: assert merge_dictionaries({ \"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\" }, { \"G\": \"Green\", \"W\": \"White\" })=={'B': 'Black', 'R': 'Red', 'P': 'Pink', 'G': 'Green', 'W': 'White'}",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate({ \"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\" }, { \"G\": \"Green\", \"W\": \"White\" })=={'B': 'Black', 'R': 'Red', 'P': 'Pink', 'G': 'Green', 'W': 'White'}\n    assert candidate({ \"R\": \"Red\", \"B\": \"Black\", \"P\": \"Pink\" },{ \"O\": \"Orange\", \"W\": \"White\", \"B\": \"Black\" })=={'O': 'Orange', 'P': 'Pink', 'B': 'Black', 'W': 'White', 'R': 'Red'}\n    assert candidate({ \"G\": \"Green\", \"W\": \"White\" },{ \"O\": \"Orange\", \"W\": \"White\", \"B\": \"Black\" })=={'W': 'White', 'O': 'Orange', 'G': 'Green', 'B': 'Black'}\n",
       "language": "python"
     },
     {
       "id": 569,
-      "input": "Write a function to sort each sublist of strings in a given list of lists.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to sort each sublist of strings in a given list of lists.\nYour code should pass this test case: assert sort_sublists([['green', 'orange'], ['black', 'white'], ['white', 'black', 'orange']])==[['green', 'orange'], ['black', 'white'], ['black', 'orange', 'white']]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([['green', 'orange'], ['black', 'white'], ['white', 'black', 'orange']])==[['green', 'orange'], ['black', 'white'], ['black', 'orange', 'white']]\n    assert candidate([['green', 'orange'], ['black'], ['green', 'orange'], ['white']])==[['green', 'orange'], ['black'], ['green', 'orange'], ['white']]\n    assert candidate([['a','b'],['d','c'],['g','h'] , ['f','e']])==[['a', 'b'], ['c', 'd'], ['g', 'h'], ['e', 'f']]\n",
       "language": "python"
     },
     {
       "id": 206,
-      "input": "Write a function to perform the adjacent element concatenation in the given tuples.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to perform the adjacent element concatenation in the given tuples.\nYour code should pass this test case: assert concatenate_elements((\"DSP \", \"IS \", \"BEST \", \"FOR \", \"ALL \", \"UTS\")) == ('DSP IS ', 'IS BEST ', 'BEST FOR ', 'FOR ALL ', 'ALL UTS')",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((\"DSP \", \"IS \", \"BEST \", \"FOR \", \"ALL \", \"UTS\")) == ('DSP IS ', 'IS BEST ', 'BEST FOR ', 'FOR ALL ', 'ALL UTS')\n    assert candidate((\"RES \", \"IS \", \"BEST \", \"FOR \", \"ALL \", \"QESR\")) == ('RES IS ', 'IS BEST ', 'BEST FOR ', 'FOR ALL ', 'ALL QESR')\n    assert candidate((\"MSAM\", \"IS \", \"BEST \", \"FOR \", \"ALL \", \"SKD\")) == ('MSAMIS ', 'IS BEST ', 'BEST FOR ', 'FOR ALL ', 'ALL SKD')\n",
       "language": "python"
     },
     {
       "id": 659,
-      "input": "Write a python function to print duplicants from a list of integers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to print duplicants from a list of integers.\nYour code should pass this test case: assert Repeat([10, 20, 30, 20, 20, 30, 40, 50, -20, 60, 60, -20, -20]) == [20, 30, -20, 60]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([10, 20, 30, 20, 20, 30, 40, 50, -20, 60, 60, -20, -20]) == [20, 30, -20, 60]\n    assert candidate([-1, 1, -1, 8]) == [-1]\n    assert candidate([1, 2, 3, 1, 2,]) == [1, 2]\n",
       "language": "python"
     },
     {
       "id": 554,
-      "input": "Write a python function to find odd numbers from a mixed list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find odd numbers from a mixed list.\nYour code should pass this test case: assert Split([1,2,3,4,5,6]) == [1,3,5]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,3,4,5,6]) == [1,3,5]\n    assert candidate([10,11,12,13]) == [11,13]\n    assert candidate([7,8,9,1]) == [7,9,1]\n",
       "language": "python"
     },
     {
       "id": 577,
-      "input": "Write a python function to find the last digit in factorial of a given number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the last digit in factorial of a given number.\nYour code should pass this test case: assert last_Digit_Factorial(4) == 4",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(4) == 4\n    assert candidate(21) == 0\n    assert candidate(30) == 0\n",
       "language": "python"
     },
     {
       "id": 387,
-      "input": "Write a python function to check whether the hexadecimal number is even or odd.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether the hexadecimal number is even or odd.\nYour code should pass this test case: assert even_or_odd(\"AB3454D\") ==\"Odd\"",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"AB3454D\") ==\"Odd\"\n    assert candidate(\"ABC\") == \"Even\"\n    assert candidate(\"AAD\") == \"Odd\"\n",
       "language": "python"
     },
     {
       "id": 218,
-      "input": "Write a python function to find the minimum operations required to make two numbers equal.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the minimum operations required to make two numbers equal.\nYour code should pass this test case: assert min_Operations(2,4) == 1",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(2,4) == 1\n    assert candidate(4,10) == 4\n    assert candidate(1,4) == 3\n",
       "language": "python"
     },
     {
       "id": 312,
-      "input": "Write a function to find the volume of a cone.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the volume of a cone.\nYour code should pass this test case: assert volume_cone(5,12)==314.15926535897927",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(5,12)==314.15926535897927\n    assert candidate(10,15)==1570.7963267948965\n    assert candidate(19,17)==6426.651371693521\n",
       "language": "python"
     },
     {
       "id": 950,
-      "input": "Write a function to display sign of the chinese zodiac for given year.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to display sign of the chinese zodiac for given year.\nYour code should pass this test case: assert chinese_zodiac(1997)==('Ox')",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(1997)==('Ox')\n    assert candidate(1998)==('Tiger')\n    assert candidate(1994)==('Dog')\n",
       "language": "python"
     },
     {
       "id": 181,
-      "input": "Write a function to find the longest common prefix in the given set of strings.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the longest common prefix in the given set of strings.\nYour code should pass this test case: assert common_prefix([\"tablets\", \"tables\", \"taxi\", \"tamarind\"], 4) == 'ta'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([\"tablets\", \"tables\", \"taxi\", \"tamarind\"], 4) == 'ta'\n    assert candidate([\"apples\", \"ape\", \"april\"], 3) == 'ap'\n    assert candidate([\"teens\", \"teenager\", \"teenmar\"], 3) == 'teen'\n",
       "language": "python"
     },
     {
       "id": 79,
-      "input": "Write a python function to check whether the length of the word is odd or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether the length of the word is odd or not.\nYour code should pass this test case: assert word_len(\"Hadoop\") == False",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"Hadoop\") == False\n    assert candidate(\"great\") == True\n    assert candidate(\"structure\") == True\n",
       "language": "python"
     },
     {
       "id": 865,
-      "input": "Write a function to print n-times a list using map function.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to print n-times a list using map function.\nYour code should pass this test case: assert ntimes_list([1, 2, 3, 4, 5, 6, 7],3)==[3, 6, 9, 12, 15, 18, 21]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7],3)==[3, 6, 9, 12, 15, 18, 21]\n    assert candidate([1, 2, 3, 4, 5, 6, 7],4)==[4, 8, 12, 16, 20, 24, 28]\n    assert candidate([1, 2, 3, 4, 5, 6, 7],10)==[10, 20, 30, 40, 50, 60, 70]\n",
       "language": "python"
     },
     {
       "id": 792,
-      "input": "Write a python function to count the number of lists in a given number of lists.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count the number of lists in a given number of lists.\nYour code should pass this test case: assert count_list([[1, 3], [5, 7], [9, 11], [13, 15, 17]]) == 4",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[1, 3], [5, 7], [9, 11], [13, 15, 17]]) == 4\n    assert candidate([[1,2],[2,3],[4,5]]) == 3\n    assert candidate([[1,0],[2,0]]) == 2\n",
       "language": "python"
     },
     {
       "id": 750,
-      "input": "Write a function to add the given tuple to the given list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to add the given tuple to the given list.\nYour code should pass this test case: assert add_tuple([5, 6, 7], (9, 10)) == [5, 6, 7, 9, 10]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([5, 6, 7], (9, 10)) == [5, 6, 7, 9, 10]\n    assert candidate([6, 7, 8], (10, 11)) == [6, 7, 8, 10, 11]\n    assert candidate([7, 8, 9], (11, 12)) == [7, 8, 9, 11, 12]\n",
       "language": "python"
     },
     {
       "id": 300,
-      "input": "Write a function to find the count of all binary sequences of length 2n such that sum of first n bits is same as sum of last n bits.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the count of all binary sequences of length 2n such that sum of first n bits is same as sum of last n bits.\nYour code should pass this test case: assert count_binary_seq(1) == 2.0",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(1) == 2.0\n    assert candidate(2) == 6.0\n    assert candidate(3) == 20.0\n",
       "language": "python"
     },
     {
       "id": 404,
-      "input": "Write a python function to find the minimum of two numbers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the minimum of two numbers.\nYour code should pass this test case: assert minimum(1,2) == 1",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(1,2) == 1\n    assert candidate(-5,-4) == -5\n    assert candidate(0,0) == 0\n",
       "language": "python"
     },
     {
       "id": 308,
-      "input": "Write a function to find the specified number of largest products from two given lists.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the specified number of largest products from two given lists.\nYour code should pass this test case: assert large_product([1, 2, 3, 4, 5, 6],[3, 6, 8, 9, 10, 6],3)==[60, 54, 50]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6],[3, 6, 8, 9, 10, 6],3)==[60, 54, 50]\n    assert candidate([1, 2, 3, 4, 5, 6],[3, 6, 8, 9, 10, 6],4)==[60, 54, 50, 48]\n    assert candidate([1, 2, 3, 4, 5, 6],[3, 6, 8, 9, 10, 6],5)==[60, 54, 50, 48, 45]\n",
       "language": "python"
     },
     {
       "id": 507,
-      "input": "Write a function to remove specific words from a given list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to remove specific words from a given list.\nYour code should pass this test case: assert remove_words(['red', 'green', 'blue', 'white', 'black', 'orange'],['white', 'orange'])==['red', 'green', 'blue', 'black']",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(['red', 'green', 'blue', 'white', 'black', 'orange'],['white', 'orange'])==['red', 'green', 'blue', 'black']\n    assert candidate(['red', 'green', 'blue', 'white', 'black', 'orange'],['black', 'orange'])==['red', 'green', 'blue', 'white']\n    assert candidate(['red', 'green', 'blue', 'white', 'black', 'orange'],['blue', 'white'])==['red', 'green', 'black', 'orange']\n",
       "language": "python"
     },
     {
       "id": 598,
-      "input": "Write a function to check whether the given number is armstrong or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check whether the given number is armstrong or not.\nYour code should pass this test case: assert armstrong_number(153)==True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(153)==True\n    assert candidate(259)==False\n    assert candidate(4458)==False\n",
       "language": "python"
     },
     {
       "id": 498,
-      "input": "Write a python function to find gcd of two positive integers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find gcd of two positive integers.\nYour code should pass this test case: assert gcd(12, 17) == 1",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(12, 17) == 1\n    assert candidate(4,6) == 2\n    assert candidate(2,9) == 1\n",
       "language": "python"
     },
     {
       "id": 90,
-      "input": "Write a python function to find the length of the longest word.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the length of the longest word.\nYour code should pass this test case: assert len_log([\"python\",\"PHP\",\"bigdata\"]) == 7",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([\"python\",\"PHP\",\"bigdata\"]) == 7\n    assert candidate([\"a\",\"ab\",\"abc\"]) == 3\n    assert candidate([\"small\",\"big\",\"tall\"]) == 5\n",
       "language": "python"
     },
     {
       "id": 343,
-      "input": "Write a function to calculate the number of digits and letters in a string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to calculate the number of digits and letters in a string.\nYour code should pass this test case: assert dig_let(\"python\")==(6,0)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"python\")==(6,0)\n    assert candidate(\"program\")==(7,0)\n    assert candidate(\"python3.0\")==(6,2)\n",
       "language": "python"
     },
     {
       "id": 790,
-      "input": "Write a python function to check whether every even index contains even numbers of a given list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether every even index contains even numbers of a given list.\nYour code should pass this test case: assert even_position([3,2,1]) == False",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([3,2,1]) == False\n    assert candidate([1,2,3]) == False\n    assert candidate([2,1,4]) == True\n",
       "language": "python"
     },
     {
       "id": 638,
-      "input": "Write a function to calculate wind chill index.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to calculate wind chill index.\nYour code should pass this test case: assert wind_chill(120,35)==40",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(120,35)==40\n    assert candidate(40,70)==86\n    assert candidate(10,100)==116\n",
       "language": "python"
     },
     {
       "id": 293,
-      "input": "Write a function to find the third side of a right angled triangle.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the third side of a right angled triangle.\nYour code should pass this test case: assert otherside_rightangle(7,8)==10.63014581273465",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(7,8)==10.63014581273465\n    assert candidate(3,4)==5\n    assert candidate(7,15)==16.55294535724685\n",
       "language": "python"
     },
     {
       "id": 465,
-      "input": "Write a function to drop empty items from a given dictionary.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to drop empty items from a given dictionary.\nYour code should pass this test case: assert drop_empty({'c1': 'Red', 'c2': 'Green', 'c3':None})=={'c1': 'Red', 'c2': 'Green'}",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate({'c1': 'Red', 'c2': 'Green', 'c3':None})=={'c1': 'Red', 'c2': 'Green'}\n    assert candidate({'c1': 'Red', 'c2': None, 'c3':None})=={'c1': 'Red'}\n    assert candidate({'c1': None, 'c2': 'Green', 'c3':None})=={ 'c2': 'Green'}\n",
       "language": "python"
     },
     {
       "id": 612,
-      "input": "Write a python function to merge the first and last elements separately in a list of lists.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to merge the first and last elements separately in a list of lists.\nYour code should pass this test case: assert merge([['x', 'y'], ['a', 'b'], ['m', 'n']]) == [['x', 'a', 'm'], ['y', 'b', 'n']]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([['x', 'y'], ['a', 'b'], ['m', 'n']]) == [['x', 'a', 'm'], ['y', 'b', 'n']]\n    assert candidate([[1, 2], [3, 4], [5, 6], [7, 8]]) == [[1, 3, 5, 7], [2, 4, 6, 8]]\n    assert candidate([['x', 'y','z' ], ['a', 'b','c'], ['m', 'n','o']]) == [['x', 'a', 'm'], ['y', 'b', 'n'],['z', 'c','o']]\n",
       "language": "python"
     },
     {
       "id": 363,
-      "input": "Write a function to add the k elements to each element in the tuple.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to add the k elements to each element in the tuple.\nYour code should pass this test case: assert add_K_element([(1, 3, 4), (2, 4, 6), (3, 8, 1)], 4) == [(5, 7, 8), (6, 8, 10), (7, 12, 5)]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([(1, 3, 4), (2, 4, 6), (3, 8, 1)], 4) == [(5, 7, 8), (6, 8, 10), (7, 12, 5)]\n    assert candidate([(1, 2, 3), (4, 5, 6), (7, 8, 9)], 8) == [(9, 10, 11), (12, 13, 14), (15, 16, 17)]\n    assert candidate([(11, 12, 13), (14, 15, 16), (17, 18, 19)], 9) == [(20, 21, 22), (23, 24, 25), (26, 27, 28)]\n",
       "language": "python"
     },
     {
       "id": 519,
-      "input": "Write a function to calculate volume of a tetrahedron.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to calculate volume of a tetrahedron.\nYour code should pass this test case: assert volume_tetrahedron(10)==117.85",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10)==117.85\n    assert candidate(15)==397.75\n    assert candidate(20)==942.81\n",
       "language": "python"
     },
     {
       "id": 762,
-      "input": "Write a function to check whether the given month number contains 30 days or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check whether the given month number contains 30 days or not.\nYour code should pass this test case: assert check_monthnumber_number(6)==True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(6)==True\n    assert candidate(2)==False\n    assert candidate(12)==False\n",
       "language": "python"
     },
     {
       "id": 263,
-      "input": "Write a function to merge two dictionaries.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to merge two dictionaries.\nYour code should pass this test case: assert merge_dict({'a': 100, 'b': 200},{'x': 300, 'y': 200})=={'x': 300, 'y': 200, 'a': 100, 'b': 200}",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate({'a': 100, 'b': 200},{'x': 300, 'y': 200})=={'x': 300, 'y': 200, 'a': 100, 'b': 200}\n    assert candidate({'a':900,'b':900,'d':900},{'a':900,'b':900,'d':900})=={'a':900,'b':900,'d':900,'a':900,'b':900,'d':900}\n    assert candidate({'a':10,'b':20},{'x':30,'y':40})=={'x':30,'y':40,'a':10,'b':20}\n",
       "language": "python"
     },
     {
       "id": 361,
-      "input": "Write a function to remove empty lists from a given list of lists.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to remove empty lists from a given list of lists.\nYour code should pass this test case: assert remove_empty([[], [], [], 'Red', 'Green', [1,2], 'Blue', [], []])==['Red', 'Green', [1, 2], 'Blue']",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[], [], [], 'Red', 'Green', [1,2], 'Blue', [], []])==['Red', 'Green', [1, 2], 'Blue']\n    assert candidate([[], [], [],[],[], 'Green', [1,2], 'Blue', [], []])==[ 'Green', [1, 2], 'Blue']\n    assert candidate([[], [], [], 'Python',[],[], 'programming', 'language',[],[],[], [], []])==['Python', 'programming', 'language']\n",
       "language": "python"
     },
     {
       "id": 442,
-      "input": "Write a function to find the ration of positive numbers in an array of integers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the ration of positive numbers in an array of integers.\nYour code should pass this test case: assert positive_count([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8])==0.54",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([0, 1, 2, -1, -5, 6, 0, -3, -2, 3, 4, 6, 8])==0.54\n    assert candidate([2, 1, 2, -1, -5, 6, 4, -3, -2, 3, 4, 6, 8])==0.69\n    assert candidate([2, 4, -6, -9, 11, -12, 14, -5, 17])==0.56\n",
       "language": "python"
     },
     {
       "id": 539,
-      "input": "Write a function to create a list containing the power of said number in bases raised to the corresponding number in the index using map function.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to create a list containing the power of said number in bases raised to the corresponding number in the index using map function.\nYour code should pass this test case: assert basesnum_coresspondingnum([10, 20, 30, 40, 50, 60, 70, 80, 90, 100],[1, 2, 3, 4, 5, 6, 7, 8, 9, 10])==[10, 400, 27000, 2560000, 312500000, 46656000000, 8235430000000, 1677721600000000, 387420489000000000, 100000000000000000000]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([10, 20, 30, 40, 50, 60, 70, 80, 90, 100],[1, 2, 3, 4, 5, 6, 7, 8, 9, 10])==[10, 400, 27000, 2560000, 312500000, 46656000000, 8235430000000, 1677721600000000, 387420489000000000, 100000000000000000000]\n    assert candidate([1, 2, 3, 4, 5, 6, 7],[10, 20, 30, 40, 50, 60, 70])==[1, 1048576, 205891132094649, 1208925819614629174706176, 88817841970012523233890533447265625, 48873677980689257489322752273774603865660850176, 143503601609868434285603076356671071740077383739246066639249]\n    assert candidate([4, 8, 12, 16, 20, 24, 28],[3, 6, 9, 12, 15, 18, 21])==[64, 262144, 5159780352, 281474976710656, 32768000000000000000, 6979147079584381377970176, 2456510688823056210273111113728]\n",
       "language": "python"
     },
     {
       "id": 370,
-      "input": "Write a function to sort a tuple by its float element.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to sort a tuple by its float element.\nYour code should pass this test case: assert float_sort([('item1', '12.20'), ('item2', '15.10'), ('item3', '24.5')])==[('item3', '24.5'), ('item2', '15.10'), ('item1', '12.20')] ",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([('item1', '12.20'), ('item2', '15.10'), ('item3', '24.5')])==[('item3', '24.5'), ('item2', '15.10'), ('item1', '12.20')] \n    assert candidate([('item1', '15'), ('item2', '10'), ('item3', '20')])==[('item3', '20'), ('item1', '15'), ('item2', '10')] \n    assert candidate([('item1', '5'), ('item2', '10'), ('item3', '14')])==[('item3', '14'), ('item2', '10'), ('item1', '5')] \n",
       "language": "python"
     },
     {
       "id": 286,
-      "input": "Write a function to find the largest sum of contiguous array in the modified array which is formed by repeating the given array k times.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the largest sum of contiguous array in the modified array which is formed by repeating the given array k times.\nYour code should pass this test case: assert max_sub_array_sum_repeated([10, 20, -30, -1], 4, 3) == 30",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([10, 20, -30, -1], 4, 3) == 30\n    assert candidate([-1, 10, 20], 3, 2) == 59\n    assert candidate([-1, -2, -3], 3, 3) == -1\n",
       "language": "python"
     },
     {
       "id": 629,
-      "input": "Write a python function to find even numbers from a mixed list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find even numbers from a mixed list.\nYour code should pass this test case: assert Split([1,2,3,4,5]) == [2,4]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,3,4,5]) == [2,4]\n    assert candidate([4,5,6,7,8,0,1]) == [4,6,8,0]\n    assert candidate([8,12,15,19]) == [8,12]\n",
       "language": "python"
     },
     {
       "id": 408,
-      "input": "Write a function to find k number of pairs which consist of one element from the first array and one element from the second array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find k number of pairs which consist of one element from the first array and one element from the second array.\nYour code should pass this test case: assert k_smallest_pairs([1,3,7],[2,4,6],2)==[[1, 2], [1, 4]]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,3,7],[2,4,6],2)==[[1, 2], [1, 4]]\n    assert candidate([1,3,7],[2,4,6],1)==[[1, 2]]\n    assert candidate([1,3,7],[2,4,6],7)==[[1, 2], [1, 4], [3, 2], [1, 6], [3, 4], [3, 6], [7, 2]]\n",
       "language": "python"
     },
     {
       "id": 786,
-      "input": "Write a function to locate the right insertion point for a specified value in sorted order.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to locate the right insertion point for a specified value in sorted order.\nYour code should pass this test case: assert right_insertion([1,2,4,5],6)==4",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,4,5],6)==4\n    assert candidate([1,2,4,5],3)==2\n    assert candidate([1,2,4,5],7)==4\n",
       "language": "python"
     },
     {
       "id": 247,
-      "input": "Write a function to find the longest palindromic subsequence in the given string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the longest palindromic subsequence in the given string.\nYour code should pass this test case: assert lps(\"TENS FOR TENS\") == 5 ",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"TENS FOR TENS\") == 5 \n    assert candidate(\"CARDIO FOR CARDS\") == 7\n    assert candidate(\"PART OF THE JOURNEY IS PART\") == 9 \n",
       "language": "python"
     },
     {
       "id": 620,
-      "input": "Write a function to find the largest subset where each pair is divisible.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the largest subset where each pair is divisible.\nYour code should pass this test case: assert largest_subset([ 1, 3, 6, 13, 17, 18 ], 6) == 4",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([ 1, 3, 6, 13, 17, 18 ], 6) == 4\n    assert candidate([10, 5, 3, 15, 20], 5) == 3\n    assert candidate([18, 1, 3, 6, 13, 17], 6) == 4\n",
       "language": "python"
     },
     {
       "id": 488,
-      "input": "Write a function to find the area of a pentagon.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the area of a pentagon.\nYour code should pass this test case: assert area_pentagon(5)==43.01193501472417",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(5)==43.01193501472417\n    assert candidate(10)==172.0477400588967\n    assert candidate(15)==387.10741513251753\n",
       "language": "python"
     },
     {
       "id": 225,
-      "input": "Write a python function to find the minimum element in a sorted and rotated array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the minimum element in a sorted and rotated array.\nYour code should pass this test case: assert find_Min([1,2,3,4,5],0,4) == 1",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,3,4,5],0,4) == 1\n    assert candidate([4,6,8],0,2) == 4\n    assert candidate([2,3,5,7,9],0,4) == 2\n",
       "language": "python"
     },
     {
       "id": 229,
-      "input": "Write a function to re-arrange the elements of the given array so that all negative elements appear before positive ones.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to re-arrange the elements of the given array so that all negative elements appear before positive ones.\nYour code should pass this test case: assert re_arrange_array([-1, 2, -3, 4, 5, 6, -7, 8, 9], 9) == [-1, -3, -7, 4, 5, 6, 2, 8, 9]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([-1, 2, -3, 4, 5, 6, -7, 8, 9], 9) == [-1, -3, -7, 4, 5, 6, 2, 8, 9]\n    assert candidate([12, -14, -26, 13, 15], 5) == [-14, -26, 12, 13, 15]\n    assert candidate([10, 24, 36, -42, -39, -78, 85], 7) == [-42, -39, -78, 10, 24, 36, 85]\n",
       "language": "python"
     },
     {
       "id": 705,
-      "input": "Write a function to sort a list of lists by length and value.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to sort a list of lists by length and value.\nYour code should pass this test case: assert sort_sublists([[2], [0], [1, 3], [0, 7], [9, 11], [13, 15, 17]])==[[0], [2], [0, 7], [1, 3], [9, 11], [13, 15, 17]]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[2], [0], [1, 3], [0, 7], [9, 11], [13, 15, 17]])==[[0], [2], [0, 7], [1, 3], [9, 11], [13, 15, 17]]\n    assert candidate([[1], [2, 3], [4, 5, 6], [7], [10, 11]])==[[1], [7], [2, 3], [10, 11], [4, 5, 6]]\n    assert candidate([[\"python\"],[\"java\",\"C\",\"C++\"],[\"DBMS\"],[\"SQL\",\"HTML\"]])==[['DBMS'], ['python'], ['SQL', 'HTML'], ['java', 'C', 'C++']]\n",
       "language": "python"
     },
     {
       "id": 284,
-      "input": "Write a function to check whether all items of a list are equal to a given string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check whether all items of a list are equal to a given string.\nYour code should pass this test case: assert check_element([\"green\", \"orange\", \"black\", \"white\"],'blue')==False",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([\"green\", \"orange\", \"black\", \"white\"],'blue')==False\n    assert candidate([1,2,3,4],7)==False\n    assert candidate([\"green\", \"green\", \"green\", \"green\"],'green')==True\n",
       "language": "python"
     },
     {
       "id": 515,
-      "input": "Write a function to check if there is a subset with sum divisible by m.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check if there is a subset with sum divisible by m.\nYour code should pass this test case: assert modular_sum([3, 1, 7, 5], 4, 6) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([3, 1, 7, 5], 4, 6) == True\n    assert candidate([1, 7], 2, 5) == False\n    assert candidate([1, 6], 2, 5) == False\n",
       "language": "python"
     },
     {
       "id": 97,
-      "input": "Write a function to find frequency count of list of lists.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find frequency count of list of lists.\nYour code should pass this test case: assert frequency_lists([[1, 2, 3, 2], [4, 5, 6, 2], [7, 8, 9, 5]])=={1: 1, 2: 3, 3: 1, 4: 1, 5: 2, 6: 1, 7: 1, 8: 1, 9: 1}",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[1, 2, 3, 2], [4, 5, 6, 2], [7, 8, 9, 5]])=={1: 1, 2: 3, 3: 1, 4: 1, 5: 2, 6: 1, 7: 1, 8: 1, 9: 1}\n    assert candidate([[1,2,3,4],[5,6,7,8],[9,10,11,12]])=={1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1, 7: 1, 8: 1, 9: 1,10:1,11:1,12:1}\n    assert candidate([[20,30,40,17],[18,16,14,13],[10,20,30,40]])=={20:2,30:2,40:2,17: 1,18:1, 16: 1,14: 1,13: 1, 10: 1}\n",
       "language": "python"
     },
     {
       "id": 826,
-      "input": "Write a python function to find the type of triangle from the given sides.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the type of triangle from the given sides.\nYour code should pass this test case: assert check_Type_Of_Triangle(1,2,3) == \"Obtuse-angled Triangle\"",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(1,2,3) == \"Obtuse-angled Triangle\"\n    assert candidate(2,2,2) == \"Acute-angled Triangle\"\n    assert candidate(1,0,1) == \"Right-angled Triangle\"\n",
       "language": "python"
     },
     {
       "id": 535,
-      "input": "Write a function to find the top or bottom surface area of a cylinder.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the top or bottom surface area of a cylinder.\nYour code should pass this test case: assert topbottom_surfacearea(10)==314.15000000000003",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10)==314.15000000000003\n    assert candidate(5)==78.53750000000001\n    assert candidate(4)==50.264\n",
       "language": "python"
     },
     {
       "id": 596,
-      "input": "Write a function to find the size of the given tuple.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the size of the given tuple.\nYour code should pass this test case: assert tuple_size((\"A\", 1, \"B\", 2, \"C\", 3) ) == sys.getsizeof((\"A\", 1, \"B\", 2, \"C\", 3))",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((\"A\", 1, \"B\", 2, \"C\", 3) ) == sys.getsizeof((\"A\", 1, \"B\", 2, \"C\", 3))\n    assert candidate((1, \"Raju\", 2, \"Nikhil\", 3, \"Deepanshu\") ) == sys.getsizeof((1, \"Raju\", 2, \"Nikhil\", 3, \"Deepanshu\"))\n    assert candidate(((1, \"Lion\"), ( 2, \"Tiger\"), (3, \"Fox\"), (4, \"Wolf\"))  ) == sys.getsizeof(((1, \"Lion\"), ( 2, \"Tiger\"), (3, \"Fox\"), (4, \"Wolf\")))\n",
       "language": "python"
     },
     {
       "id": 267,
-      "input": "Write a python function to find the sum of squares of first n odd natural numbers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the sum of squares of first n odd natural numbers.\nYour code should pass this test case: assert square_Sum(2) == 10",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(2) == 10\n    assert candidate(3) == 35\n    assert candidate(4) == 84\n",
       "language": "python"
     },
     {
       "id": 946,
-      "input": "Write a function to find the most common elements and their counts of a specified text.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the most common elements and their counts of a specified text.\nYour code should pass this test case: assert most_common_elem('lkseropewdssafsdfafkpwe',3)==[('s', 4), ('e', 3), ('f', 3)] ",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('lkseropewdssafsdfafkpwe',3)==[('s', 4), ('e', 3), ('f', 3)] \n    assert candidate('lkseropewdssafsdfafkpwe',2)==[('s', 4), ('e', 3)]\n    assert candidate('lkseropewdssafsdfafkpwe',7)==[('s', 4), ('e', 3), ('f', 3), ('k', 2), ('p', 2), ('w', 2), ('d', 2)]\n",
       "language": "python"
     },
     {
       "id": 314,
-      "input": "Write a function to find out the maximum sum such that no two chosen numbers are adjacent for the given rectangular grid of dimension 2 x n.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find out the maximum sum such that no two chosen numbers are adjacent for the given rectangular grid of dimension 2 x n.\nYour code should pass this test case: assert max_sum_rectangular_grid([ [1, 4, 5], [2, 0, 0 ] ], 3) == 7",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([ [1, 4, 5], [2, 0, 0 ] ], 3) == 7\n    assert candidate([ [ 1, 2, 3, 4, 5], [ 6, 7, 8, 9, 10] ], 5) == 24\n    assert candidate([ [7, 9, 11, 15, 19], [21, 25, 28, 31, 32] ], 5) == 81\n",
       "language": "python"
     },
     {
       "id": 727,
-      "input": "Write a function to remove all characters except letters and numbers using regex",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to remove all characters except letters and numbers using regex\nYour code should pass this test case: assert remove_char(\"123abcjw:, .@! eiw\") == '123abcjweiw'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"123abcjw:, .@! eiw\") == '123abcjweiw'\n    assert candidate(\"Hello1234:, ! Howare33u\") == 'Hello1234Howare33u'\n    assert candidate(\"Cool543Triks@:, Make@987Trips\") == 'Cool543TriksMake987Trips' \n",
       "language": "python"
     },
     {
       "id": 974,
-      "input": "Write a function to find the minimum total path sum in the given triangle.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the minimum total path sum in the given triangle.\nYour code should pass this test case: assert min_sum_path([[ 2 ], [3, 9 ], [1, 6, 7 ]]) == 6",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[ 2 ], [3, 9 ], [1, 6, 7 ]]) == 6\n    assert candidate([[ 2 ], [3, 7 ], [8, 5, 6 ]]) == 10 \n    assert candidate([[ 3 ], [6, 4 ], [5, 2, 7 ]]) == 9\n",
       "language": "python"
     },
     {
       "id": 287,
-      "input": "Write a python function to find the sum of squares of first n even natural numbers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the sum of squares of first n even natural numbers.\nYour code should pass this test case: assert square_Sum(2) == 20",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(2) == 20\n    assert candidate(3) == 56\n    assert candidate(4) == 120\n",
       "language": "python"
     },
     {
       "id": 919,
-      "input": "Write a python function to multiply all items in the list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to multiply all items in the list.\nYour code should pass this test case: assert multiply_list([1,-2,3]) == -6",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,-2,3]) == -6\n    assert candidate([1,2,3,4]) == 24\n    assert candidate([3,1,2,3]) == 18\n",
       "language": "python"
     },
     {
       "id": 468,
-      "input": "Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the maximum product formed by multiplying numbers of an increasing subsequence of that array.\nYour code should pass this test case: assert max_product([3, 100, 4, 5, 150, 6], 6) == 45000 ",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([3, 100, 4, 5, 150, 6], 6) == 45000 \n    assert candidate([4, 42, 55, 68, 80], 5) == 50265600\n    assert candidate([10, 22, 9, 33, 21, 50, 41, 60], 8) == 21780000 \n",
       "language": "python"
     },
     {
       "id": 182,
-      "input": "Write a function to find uppercase, lowercase, special character and numeric values using regex.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find uppercase, lowercase, special character and numeric values using regex.\nYour code should pass this test case: assert find_character(\"ThisIsGeeksforGeeks\") == (['T', 'I', 'G', 'G'], ['h', 'i', 's', 's', 'e', 'e', 'k', 's', 'f', 'o', 'r', 'e', 'e', 'k', 's'], [], [])",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"ThisIsGeeksforGeeks\") == (['T', 'I', 'G', 'G'], ['h', 'i', 's', 's', 'e', 'e', 'k', 's', 'f', 'o', 'r', 'e', 'e', 'k', 's'], [], [])\n    assert candidate(\"Hithere2\") == (['H'], ['i', 't', 'h', 'e', 'r', 'e'], ['2'], [])\n    assert candidate(\"HeyFolks32\") == (['H', 'F'], ['e', 'y', 'o', 'l', 'k', 's'], ['3', '2'], [])\n",
       "language": "python"
     },
     {
       "id": 248,
-      "input": "Write a function to calculate the harmonic sum of n-1.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to calculate the harmonic sum of n-1.\nYour code should pass this test case: assert harmonic_sum(7) == 2.5928571428571425",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(7) == 2.5928571428571425\n    assert candidate(4) == 2.083333333333333\n    assert candidate(19) == 3.547739657143682\n",
       "language": "python"
     },
     {
       "id": 722,
-      "input": "Write a function to filter the height and width of students which are stored in a dictionary.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to filter the height and width of students which are stored in a dictionary.\nYour code should pass this test case: assert filter_data({'Cierra Vega': (6.2, 70), 'Alden Cantrell': (5.9, 65), 'Kierra Gentry': (6.0, 68), 'Pierre Cox': (5.8, 66)},6.0,70)=={'Cierra Vega': (6.2, 70)}",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate({'Cierra Vega': (6.2, 70), 'Alden Cantrell': (5.9, 65), 'Kierra Gentry': (6.0, 68), 'Pierre Cox': (5.8, 66)},6.0,70)=={'Cierra Vega': (6.2, 70)}\n    assert candidate({'Cierra Vega': (6.2, 70), 'Alden Cantrell': (5.9, 65), 'Kierra Gentry': (6.0, 68), 'Pierre Cox': (5.8, 66)},5.9,67)=={'Cierra Vega': (6.2, 70),'Kierra Gentry': (6.0, 68)}\n    assert candidate({'Cierra Vega': (6.2, 70), 'Alden Cantrell': (5.9, 65), 'Kierra Gentry': (6.0, 68), 'Pierre Cox': (5.8, 66)},5.7,64)=={'Cierra Vega': (6.2, 70),'Alden Cantrell': (5.9, 65),'Kierra Gentry': (6.0, 68),'Pierre Cox': (5.8, 66)}\n",
       "language": "python"
     },
     {
       "id": 234,
-      "input": "Write a function to find the volume of a cube.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the volume of a cube.\nYour code should pass this test case: assert volume_cube(3)==27",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(3)==27\n    assert candidate(2)==8\n    assert candidate(5)==125\n",
       "language": "python"
     },
     {
       "id": 511,
-      "input": "Write a python function to find minimum sum of factors of a given number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find minimum sum of factors of a given number.\nYour code should pass this test case: assert find_Min_Sum(12) == 7",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(12) == 7\n    assert candidate(105) == 15\n    assert candidate(2) == 2\n",
       "language": "python"
     },
     {
       "id": 156,
-      "input": "Write a function to convert a tuple of string values to a tuple of integer values.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to convert a tuple of string values to a tuple of integer values.\nYour code should pass this test case: assert tuple_int_str((('333', '33'), ('1416', '55')))==((333, 33), (1416, 55))",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((('333', '33'), ('1416', '55')))==((333, 33), (1416, 55))\n    assert candidate((('999', '99'), ('1000', '500')))==((999, 99), (1000, 500))\n    assert candidate((('666', '66'), ('1500', '555')))==((666, 66), (1500, 555))\n",
       "language": "python"
     },
     {
       "id": 193,
-      "input": "Write a function to remove the duplicates from the given tuple.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to remove the duplicates from the given tuple.\nYour code should pass this test case: assert remove_tuple((1, 3, 5, 2, 3, 5, 1, 1, 3)) == (1, 2, 3, 5)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((1, 3, 5, 2, 3, 5, 1, 1, 3)) == (1, 2, 3, 5)\n    assert candidate((2, 3, 4, 4, 5, 6, 6, 7, 8, 8)) == (2, 3, 4, 5, 6, 7, 8)\n    assert candidate((11, 12, 13, 11, 11, 12, 14, 13)) == (11, 12, 13, 14)\n",
       "language": "python"
     },
     {
       "id": 251,
-      "input": "Write a function to insert an element before each element of a list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to insert an element before each element of a list.\nYour code should pass this test case: assert insert_element(['Red', 'Green', 'Black'] ,'c')==['c', 'Red', 'c', 'Green', 'c', 'Black'] ",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(['Red', 'Green', 'Black'] ,'c')==['c', 'Red', 'c', 'Green', 'c', 'Black'] \n    assert candidate(['python', 'java'] ,'program')==['program', 'python', 'program', 'java'] \n    assert candidate(['happy', 'sad'] ,'laugh')==['laugh', 'happy', 'laugh', 'sad'] \n",
       "language": "python"
     },
     {
       "id": 11,
-      "input": "Write a python function to remove first and last occurrence of a given character from the string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to remove first and last occurrence of a given character from the string.\nYour code should pass this test case: assert remove_Occ(\"hello\",\"l\") == \"heo\"",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"hello\",\"l\") == \"heo\"\n    assert candidate(\"abcda\",\"a\") == \"bcd\"\n    assert candidate(\"PHP\",\"P\") == \"H\"\n    assert candidate(\"hellolloll\",\"l\") == \"helollol\"\n    assert candidate(\"\",\"l\") == \"\"\n",
       "language": "python"
     },
     {
       "id": 904,
-      "input": "Write a function to return true if the given number is even else return false.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to return true if the given number is even else return false.\nYour code should pass this test case: assert even_num(13.5)==False",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(13.5)==False\n    assert candidate(0)==True\n    assert candidate(-9)==False\n",
       "language": "python"
     },
     {
       "id": 842,
-      "input": "Write a function to find the number which occurs for odd number of times in the given array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the number which occurs for odd number of times in the given array.\nYour code should pass this test case: assert get_odd_occurence([2, 3, 5, 4, 5, 2, 4, 3, 5, 2, 4, 4, 2], 13) == 5",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([2, 3, 5, 4, 5, 2, 4, 3, 5, 2, 4, 4, 2], 13) == 5\n    assert candidate([1, 2, 3, 2, 3, 1, 3], 7) == 3\n    assert candidate([5, 7, 2, 7, 5, 2, 5], 7) == 5\n",
       "language": "python"
     },
     {
       "id": 829,
-      "input": "Write a function to find out the second most repeated (or frequent) string in the given sequence.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find out the second most repeated (or frequent) string in the given sequence.\nYour code should pass this test case: assert second_frequent(['aaa','bbb','ccc','bbb','aaa','aaa']) == 'bbb'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(['aaa','bbb','ccc','bbb','aaa','aaa']) == 'bbb'\n    assert candidate(['abc','bcd','abc','bcd','bcd','bcd']) == 'abc'\n    assert candidate(['cdma','gsm','hspa','gsm','cdma','cdma']) == 'gsm'\n",
       "language": "python"
     },
     {
       "id": 68,
-      "input": "Write a python function to check whether the given array is monotonic or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether the given array is monotonic or not.\nYour code should pass this test case: assert is_Monotonic([6, 5, 4, 4]) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([6, 5, 4, 4]) == True\n    assert candidate([1, 2, 2, 3]) == True\n    assert candidate([1, 3, 2]) == False\n",
       "language": "python"
     },
     {
       "id": 34,
-      "input": "Write a python function to find the missing number in a sorted array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the missing number in a sorted array.\nYour code should pass this test case: assert find_missing([1,2,3,5],4) == 4",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,3,5],4) == 4\n    assert candidate([1,3,4,5],4) == 2\n    assert candidate([1,2,3,5,6,7],5) == 4\n",
       "language": "python"
     },
     {
       "id": 844,
-      "input": "Write a python function to find the kth element in an array containing odd elements first and then even elements.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the kth element in an array containing odd elements first and then even elements.\nYour code should pass this test case: assert get_Number(8,5) == 2",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(8,5) == 2\n    assert candidate(7,2) == 3\n    assert candidate(5,2) == 3\n",
       "language": "python"
     },
     {
       "id": 254,
-      "input": "Write a function to find all words starting with 'a' or 'e' in a given string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find all words starting with 'a' or 'e' in a given string.\nYour code should pass this test case: assert words_ae(\"python programe\")==['ame']",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"python programe\")==['ame']\n    assert candidate(\"python programe language\")==['ame','anguage']\n    assert candidate(\"assert statement\")==['assert', 'atement']\n",
       "language": "python"
     },
     {
       "id": 751,
-      "input": "Write a function to check if the given array represents min heap or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check if the given array represents min heap or not.\nYour code should pass this test case: assert check_min_heap([1, 2, 3, 4, 5, 6], 0) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6], 0) == True\n    assert candidate([2, 3, 4, 5, 10, 15], 0) == True\n    assert candidate([2, 10, 4, 5, 3, 15], 0) == False\n",
       "language": "python"
     },
     {
       "id": 797,
-      "input": "Write a python function to find the sum of all odd natural numbers within the range l and r.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the sum of all odd natural numbers within the range l and r.\nYour code should pass this test case: assert sum_in_Range(2,5) == 8",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(2,5) == 8\n    assert candidate(5,7) == 12\n    assert candidate(7,13) == 40\n",
       "language": "python"
     },
     {
       "id": 548,
-      "input": "Write a function to find the length of the longest increasing subsequence of the given sequence.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the length of the longest increasing subsequence of the given sequence.\nYour code should pass this test case: assert longest_increasing_subsequence([10, 22, 9, 33, 21, 50, 41, 60]) == 5",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([10, 22, 9, 33, 21, 50, 41, 60]) == 5\n    assert candidate([3, 10, 2, 1, 20]) == 3\n    assert candidate([50, 3, 10, 7, 40, 80]) == 4 \n",
       "language": "python"
     },
     {
       "id": 781,
-      "input": "Write a python function to check whether the count of divisors is even or odd.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether the count of divisors is even or odd.\nYour code should pass this test case: assert count_Divisors(10) == \"Even\"",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10) == \"Even\"\n    assert candidate(100) == \"Odd\"\n    assert candidate(125) == \"Even\"\n",
       "language": "python"
     },
     {
       "id": 381,
-      "input": "Write a function to sort a list of lists by a given index of the inner list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to sort a list of lists by a given index of the inner list.\nYour code should pass this test case: assert index_on_inner_list([('Greyson Fulton', 98, 99), ('Brady Kent', 97, 96), ('Wyatt Knott', 91, 94), ('Beau Turnbull', 94, 98)] ,0)==[('Beau Turnbull', 94, 98), ('Brady Kent', 97, 96), ('Greyson Fulton', 98, 99), ('Wyatt Knott', 91, 94)]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([('Greyson Fulton', 98, 99), ('Brady Kent', 97, 96), ('Wyatt Knott', 91, 94), ('Beau Turnbull', 94, 98)] ,0)==[('Beau Turnbull', 94, 98), ('Brady Kent', 97, 96), ('Greyson Fulton', 98, 99), ('Wyatt Knott', 91, 94)]\n    assert candidate([('Greyson Fulton', 98, 99), ('Brady Kent', 97, 96), ('Wyatt Knott', 91, 94), ('Beau Turnbull', 94, 98)] ,1)==[('Wyatt Knott', 91, 94), ('Beau Turnbull', 94, 98), ('Brady Kent', 97, 96), ('Greyson Fulton', 98, 99)]\n    assert candidate([('Greyson Fulton', 98, 99), ('Brady Kent', 97, 96), ('Wyatt Knott', 91, 94), ('Beau Turnbull', 94, 98)] ,2)==[('Wyatt Knott', 91, 94), ('Brady Kent', 97, 96), ('Beau Turnbull', 94, 98), ('Greyson Fulton', 98, 99)]\n",
       "language": "python"
     },
     {
       "id": 847,
-      "input": "Write a python function to copy a list from a singleton tuple.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to copy a list from a singleton tuple.\nYour code should pass this test case: assert lcopy([1, 2, 3]) == [1, 2, 3]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 2, 3]) == [1, 2, 3]\n    assert candidate([4, 8, 2, 10, 15, 18]) == [4, 8, 2, 10, 15, 18]\n    assert candidate([4, 5, 6]) == [4, 5, 6]\n\n",
       "language": "python"
     },
     {
       "id": 939,
-      "input": "Write a function to sort a list of dictionaries using lambda function.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to sort a list of dictionaries using lambda function.\nYour code should pass this test case: assert sorted_models([{'make':'Nokia', 'model':216, 'color':'Black'}, {'make':'Mi Max', 'model':2, 'color':'Gold'}, {'make':'Samsung', 'model': 7, 'color':'Blue'}])==[{'make': 'Nokia', 'model': 216, 'color': 'Black'}, {'make': 'Samsung', 'model': 7, 'color': 'Blue'}, {'make': 'Mi Max', 'model': 2, 'color': 'Gold'}]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([{'make':'Nokia', 'model':216, 'color':'Black'}, {'make':'Mi Max', 'model':2, 'color':'Gold'}, {'make':'Samsung', 'model': 7, 'color':'Blue'}])==[{'make': 'Nokia', 'model': 216, 'color': 'Black'}, {'make': 'Samsung', 'model': 7, 'color': 'Blue'}, {'make': 'Mi Max', 'model': 2, 'color': 'Gold'}]\n    assert candidate([{'make':'Vivo', 'model':20,'color':'Blue'},{'make': 'oppo','model':17,'color':'Gold'},{'make':'Apple','model':11,'color':'red'}])==([{'make':'Vivo', 'model':20,'color':'Blue'},{'make': 'oppo','model':17,'color':'Gold'},{'make':'Apple','model':11,'color':'red'}])\n    assert candidate([{'make':'micromax','model':40,'color':'grey'},{'make':'poco','model':60,'color':'blue'}])==([{'make':'poco','model':60,'color':'blue'},{'make':'micromax','model':40,'color':'grey'}])\n",
       "language": "python"
     },
     {
       "id": 107,
-      "input": "Write a python function to count hexadecimal numbers for a given range.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count hexadecimal numbers for a given range.\nYour code should pass this test case: assert count_Hexadecimal(10,15) == 6",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10,15) == 6\n    assert candidate(2,4) == 0\n    assert candidate(15,16) == 1\n",
       "language": "python"
     },
     {
       "id": 444,
-      "input": "Write a function to trim each tuple by k in the given tuple list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to trim each tuple by k in the given tuple list.\nYour code should pass this test case: assert trim_tuple([(5, 3, 2, 1, 4), (3, 4, 9, 2, 1),(9, 1, 2, 3, 5), (4, 8, 2, 1, 7)], 2) == '[(2,), (9,), (2,), (2,)]'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([(5, 3, 2, 1, 4), (3, 4, 9, 2, 1),(9, 1, 2, 3, 5), (4, 8, 2, 1, 7)], 2) == '[(2,), (9,), (2,), (2,)]'\n    assert candidate([(5, 3, 2, 1, 4), (3, 4, 9, 2, 1), (9, 1, 2, 3, 5), (4, 8, 2, 1, 7)], 1) == '[(3, 2, 1), (4, 9, 2), (1, 2, 3), (8, 2, 1)]'\n    assert candidate([(7, 8, 4, 9), (11, 8, 12, 4),(4, 1, 7, 8), (3, 6, 9, 7)], 1) == '[(8, 4), (8, 12), (1, 7), (6, 9)]'\n",
       "language": "python"
     },
     {
       "id": 434,
-      "input": "Write a function that matches a string that has an a followed by one or more b's.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function that matches a string that has an a followed by one or more b's.\nYour code should pass this test case: assert text_match_one(\"ac\")==('Not matched!')",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"ac\")==('Not matched!')\n    assert candidate(\"dc\")==('Not matched!')\n    assert candidate(\"abba\")==('Found a match!')\n",
       "language": "python"
     },
     {
       "id": 492,
-      "input": "Write a function to search an element in the given array by using binary search.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to search an element in the given array by using binary search.\nYour code should pass this test case: assert binary_search([1,2,3,5,8], 6) == False",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,3,5,8], 6) == False\n    assert candidate([7, 8, 9, 10, 13], 10) == True\n    assert candidate([11, 13, 14, 19, 22, 36], 23) == False\n",
       "language": "python"
     },
     {
       "id": 57,
-      "input": "Write a python function to find the largest number that can be formed with the given digits.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the largest number that can be formed with the given digits.\nYour code should pass this test case: assert find_Max_Num([1,2,3],3) == 321",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,3],3) == 321\n    assert candidate([4,5,6,1],4) == 6541\n    assert candidate([1,2,3,9],4) == 9321\n",
       "language": "python"
     },
     {
       "id": 39,
-      "input": "Write a function to check if the letters of a given string can be rearranged so that two characters that are adjacent to each other are different.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check if the letters of a given string can be rearranged so that two characters that are adjacent to each other are different.\nYour code should pass this test case: assert rearange_string(\"aab\")==('aba')",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"aab\")==('aba')\n    assert candidate(\"aabb\")==('abab')\n    assert candidate(\"abccdd\")==('cdabcd')\n",
       "language": "python"
     },
     {
       "id": 956,
-      "input": "Write a function to split the given string at uppercase letters by using regex.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to split the given string at uppercase letters by using regex.\nYour code should pass this test case: assert split_list(\"LearnToBuildAnythingWithGoogle\") == ['Learn', 'To', 'Build', 'Anything', 'With', 'Google']",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"LearnToBuildAnythingWithGoogle\") == ['Learn', 'To', 'Build', 'Anything', 'With', 'Google']\n    assert candidate(\"ApmlifyingTheBlack+DeveloperCommunity\") == ['Apmlifying', 'The', 'Black+', 'Developer', 'Community']\n    assert candidate(\"UpdateInTheGoEcoSystem\") == ['Update', 'In', 'The', 'Go', 'Eco', 'System']\n",
       "language": "python"
     },
     {
       "id": 106,
-      "input": "Write a function to add the given list to the given tuples.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to add the given list to the given tuples.\nYour code should pass this test case: assert add_lists([5, 6, 7], (9, 10)) == (9, 10, 5, 6, 7)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([5, 6, 7], (9, 10)) == (9, 10, 5, 6, 7)\n    assert candidate([6, 7, 8], (10, 11)) == (10, 11, 6, 7, 8)\n    assert candidate([7, 8, 9], (11, 12)) == (11, 12, 7, 8, 9)\n",
       "language": "python"
     },
     {
       "id": 835,
-      "input": "Write a python function to find the slope of a line.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the slope of a line.\nYour code should pass this test case: assert slope(4,2,2,5) == -1.5",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(4,2,2,5) == -1.5\n    assert candidate(2,4,4,6) == 1\n    assert candidate(1,2,4,2) == 0\n",
       "language": "python"
     },
     {
       "id": 275,
-      "input": "Write a python function to find the position of the last removed element from the given array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the position of the last removed element from the given array.\nYour code should pass this test case: assert get_Position([2,5,4],3,2) == 2",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([2,5,4],3,2) == 2\n    assert candidate([4,3],2,2) == 2\n    assert candidate([1,2,3,4],4,1) == 4\n",
       "language": "python"
     },
     {
       "id": 587,
-      "input": "Write a function to convert a list to a tuple.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to convert a list to a tuple.\nYour code should pass this test case: assert list_tuple([5, 10, 7, 4, 15, 3])==(5, 10, 7, 4, 15, 3)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([5, 10, 7, 4, 15, 3])==(5, 10, 7, 4, 15, 3)\n    assert candidate([2, 4, 5, 6, 2, 3, 4, 4, 7])==(2, 4, 5, 6, 2, 3, 4, 4, 7)\n    assert candidate([58,44,56])==(58,44,56)\n",
       "language": "python"
     },
     {
       "id": 237,
-      "input": "Write a function to check the occurrences of records which occur similar times in the given tuples.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check the occurrences of records which occur similar times in the given tuples.\nYour code should pass this test case: assert check_occurences([(3, 1), (1, 3), (2, 5), (5, 2), (6, 3)] ) == {(1, 3): 2, (2, 5): 2, (3, 6): 1}",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([(3, 1), (1, 3), (2, 5), (5, 2), (6, 3)] ) == {(1, 3): 2, (2, 5): 2, (3, 6): 1}\n    assert candidate([(4, 2), (2, 4), (3, 6), (6, 3), (7, 4)] ) == {(2, 4): 2, (3, 6): 2, (4, 7): 1}\n    assert candidate([(13, 2), (11, 23), (12, 25), (25, 12), (16, 23)] ) == {(2, 13): 1, (11, 23): 1, (12, 25): 2, (16, 23): 1}\n",
       "language": "python"
     },
     {
       "id": 562,
-      "input": "Write a python function to find the maximum length of sublist.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the maximum length of sublist.\nYour code should pass this test case: assert Find_Max_Length([[1],[1,4],[5,6,7,8]]) == 4",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[1],[1,4],[5,6,7,8]]) == 4\n    assert candidate([[0,1],[2,2,],[3,2,1]]) == 3\n    assert candidate([[7],[22,23],[13,14,15],[10,20,30,40,50]]) == 5\n",
       "language": "python"
     },
     {
       "id": 653,
-      "input": "Write a function to group a sequence of key-value pairs into a dictionary of lists using collections module.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to group a sequence of key-value pairs into a dictionary of lists using collections module.\nYour code should pass this test case: assert grouping_dictionary([('yellow', 1), ('blue', 2), ('yellow', 3), ('blue', 4), ('red', 1)])== ({'yellow': [1, 3], 'blue': [2, 4], 'red': [1]})",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([('yellow', 1), ('blue', 2), ('yellow', 3), ('blue', 4), ('red', 1)])== ({'yellow': [1, 3], 'blue': [2, 4], 'red': [1]})\n    assert candidate([('yellow', 10), ('blue', 20), ('yellow', 30), ('blue', 40), ('red', 10)])== ({'yellow': [10, 30], 'blue': [20, 40], 'red': [10]})\n    assert candidate([('yellow', 15), ('blue', 25), ('yellow', 35), ('blue', 45), ('red', 15)])== ({'yellow': [15, 35], 'blue': [25, 45], 'red': [15]})\n",
       "language": "python"
     },
     {
       "id": 785,
-      "input": "Write a function to convert tuple string to integer tuple.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to convert tuple string to integer tuple.\nYour code should pass this test case: assert tuple_str_int(\"(7, 8, 9)\") == (7, 8, 9)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"(7, 8, 9)\") == (7, 8, 9)\n    assert candidate(\"(1, 2, 3)\") == (1, 2, 3)\n    assert candidate(\"(4, 5, 6)\") == (4, 5, 6)\n",
       "language": "python"
     },
     {
       "id": 840,
-      "input": "Write a python function to check whether the roots of a quadratic equation are numerically equal but opposite in sign or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether the roots of a quadratic equation are numerically equal but opposite in sign or not.\nYour code should pass this test case: assert Check_Solution(2,0,-1) == \"Yes\"",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(2,0,-1) == \"Yes\"\n    assert candidate(1,-5,6) == \"No\"\n    assert candidate(2,0,2) == \"Yes\"\n",
       "language": "python"
     },
     {
       "id": 849,
-      "input": "Write a python function to find sum of all prime divisors of a given number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find sum of all prime divisors of a given number.\nYour code should pass this test case: assert Sum(60) == 10",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(60) == 10\n    assert candidate(39) == 16\n    assert candidate(40) == 7\n",
       "language": "python"
     },
     {
       "id": 572,
-      "input": "Write a python function to remove two duplicate numbers from a given number of lists.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to remove two duplicate numbers from a given number of lists.\nYour code should pass this test case: assert two_unique_nums([1,2,3,2,3,4,5]) == [1, 4, 5]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,3,2,3,4,5]) == [1, 4, 5]\n    assert candidate([1,2,3,2,4,5]) == [1, 3, 4, 5]\n    assert candidate([1,2,3,4,5]) == [1, 2, 3, 4, 5]\n",
       "language": "python"
     },
     {
       "id": 520,
-      "input": "Write a function to find the lcm of the given array elements.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the lcm of the given array elements.\nYour code should pass this test case: assert get_lcm([2, 7, 3, 9, 4]) == 252",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([2, 7, 3, 9, 4]) == 252\n    assert candidate([1, 2, 8, 3]) == 24\n    assert candidate([3, 8, 4, 10, 5]) == 120\n",
       "language": "python"
     },
     {
       "id": 323,
-      "input": "Write a function to re-arrange the given array in alternating positive and negative items.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to re-arrange the given array in alternating positive and negative items.\nYour code should pass this test case: assert re_arrange([-5, -2, 5, 2, 4,\t7, 1, 8, 0, -8], 10) == [-5, 5, -2, 2, -8, 4, 7, 1, 8, 0]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([-5, -2, 5, 2, 4,\t7, 1, 8, 0, -8], 10) == [-5, 5, -2, 2, -8, 4, 7, 1, 8, 0]\n    assert candidate([1, 2, 3, -4, -1, 4], 6) == [-4, 1, -1, 2, 3, 4]\n    assert candidate([4, 7, 9, 77, -4, 5, -3, -9], 8) == [-4, 4, -3, 7, -9, 9, 77, 5]\n",
       "language": "python"
     },
     {
       "id": 401,
-      "input": "Write a function to perform index wise addition of tuple elements in the given two nested tuples.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to perform index wise addition of tuple elements in the given two nested tuples.\nYour code should pass this test case: assert add_nested_tuples(((1, 3), (4, 5), (2, 9), (1, 10)), ((6, 7), (3, 9), (1, 1), (7, 3))) == ((7, 10), (7, 14), (3, 10), (8, 13))",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(((1, 3), (4, 5), (2, 9), (1, 10)), ((6, 7), (3, 9), (1, 1), (7, 3))) == ((7, 10), (7, 14), (3, 10), (8, 13))\n    assert candidate(((2, 4), (5, 6), (3, 10), (2, 11)), ((7, 8), (4, 10), (2, 2), (8, 4))) == ((9, 12), (9, 16), (5, 12), (10, 15))\n    assert candidate(((3, 5), (6, 7), (4, 11), (3, 12)), ((8, 9), (5, 11), (3, 3), (9, 5))) == ((11, 14), (11, 18), (7, 14), (12, 17))\n",
       "language": "python"
     },
     {
       "id": 302,
-      "input": "Write a python function to find the most significant bit number which is also a set bit.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the most significant bit number which is also a set bit.\nYour code should pass this test case: assert set_Bit_Number(6) == 4",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(6) == 4\n    assert candidate(10) == 8\n    assert candidate(18) == 16\n",
       "language": "python"
     },
     {
       "id": 151,
-      "input": "Write a python function to check whether the given number is co-prime or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether the given number is co-prime or not.\nYour code should pass this test case: assert is_coprime(17,13) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(17,13) == True\n    assert candidate(15,21) == False\n    assert candidate(25,45) == False\n",
       "language": "python"
     },
     {
       "id": 662,
-      "input": "Write a function to sort a list in a dictionary.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to sort a list in a dictionary.\nYour code should pass this test case: assert sorted_dict({'n1': [2, 3, 1], 'n2': [5, 1, 2], 'n3': [3, 2, 4]})=={'n1': [1, 2, 3], 'n2': [1, 2, 5], 'n3': [2, 3, 4]}",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate({'n1': [2, 3, 1], 'n2': [5, 1, 2], 'n3': [3, 2, 4]})=={'n1': [1, 2, 3], 'n2': [1, 2, 5], 'n3': [2, 3, 4]}\n    assert candidate({'n1': [25,37,41], 'n2': [41,54,63], 'n3': [29,38,93]})=={'n1': [25, 37, 41], 'n2': [41, 54, 63], 'n3': [29, 38, 93]}\n    assert candidate({'n1': [58,44,56], 'n2': [91,34,58], 'n3': [100,200,300]})=={'n1': [44, 56, 58], 'n2': [34, 58, 91], 'n3': [100, 200, 300]}\n",
       "language": "python"
     },
     {
       "id": 421,
-      "input": "Write a function to concatenate each element of tuple by the delimiter.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to concatenate each element of tuple by the delimiter.\nYour code should pass this test case: assert concatenate_tuple((\"ID\", \"is\", 4, \"UTS\") ) == 'ID-is-4-UTS'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((\"ID\", \"is\", 4, \"UTS\") ) == 'ID-is-4-UTS'\n    assert candidate((\"QWE\", \"is\", 4, \"RTY\") ) == 'QWE-is-4-RTY'\n    assert candidate((\"ZEN\", \"is\", 4, \"OP\") ) == 'ZEN-is-4-OP'\n",
       "language": "python"
     },
     {
       "id": 456,
-      "input": "Write a function to reverse strings in a given list of string values.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to reverse strings in a given list of string values.\nYour code should pass this test case: assert reverse_string_list(['Red', 'Green', 'Blue', 'White', 'Black'])==['deR', 'neerG', 'eulB', 'etihW', 'kcalB']",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(['Red', 'Green', 'Blue', 'White', 'Black'])==['deR', 'neerG', 'eulB', 'etihW', 'kcalB']\n    assert candidate(['john','amal','joel','george'])==['nhoj','lama','leoj','egroeg']\n    assert candidate(['jack','john','mary'])==['kcaj','nhoj','yram']\n",
       "language": "python"
     },
     {
       "id": 772,
-      "input": "Write a function to remove all the words with k length in the given string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to remove all the words with k length in the given string.\nYour code should pass this test case: assert remove_length('The person is most value tet', 3) == 'person is most value'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('The person is most value tet', 3) == 'person is most value'\n    assert candidate('If you told me about this ok', 4) == 'If you me about ok'\n    assert candidate('Forces of darkeness is come into the play', 4) == 'Forces of darkeness is the'\n",
       "language": "python"
     },
     {
       "id": 388,
-      "input": "Write a python function to find the highest power of 2 that is less than or equal to n.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the highest power of 2 that is less than or equal to n.\nYour code should pass this test case: assert highest_Power_of_2(10) == 8",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10) == 8\n    assert candidate(19) == 16\n    assert candidate(32) == 32\n",
       "language": "python"
     },
     {
       "id": 61,
-      "input": "Write a python function to count number of substrings with the sum of digits equal to their length.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count number of substrings with the sum of digits equal to their length.\nYour code should pass this test case: assert count_Substrings('112112',6) == 6",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('112112',6) == 6\n    assert candidate('111',3) == 6\n    assert candidate('1101112',7) == 12\n",
       "language": "python"
     },
     {
       "id": 204,
-      "input": "Write a python function to count the occurrence of a given character in a string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count the occurrence of a given character in a string.\nYour code should pass this test case: assert count(\"abcc\",\"c\") == 2",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"abcc\",\"c\") == 2\n    assert candidate(\"ababca\",\"a\") == 3\n    assert candidate(\"mnmm0pm\",\"m\") == 4\n",
       "language": "python"
     },
     {
       "id": 28,
-      "input": "Write a python function to find binomial co-efficient.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find binomial co-efficient.\nYour code should pass this test case: assert binomial_Coeff(5,2) == 10",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(5,2) == 10\n    assert candidate(4,3) == 4\n    assert candidate(3,2) == 3\n    assert candidate(14,6) == 3003\n",
       "language": "python"
     },
     {
       "id": 5,
-      "input": "Write a function to find the number of ways to fill it with 2 x 1 dominoes for the given 3 x n board.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the number of ways to fill it with 2 x 1 dominoes for the given 3 x n board.\nYour code should pass this test case: assert count_ways(2) == 3",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(2) == 3\n    assert candidate(8) == 153\n    assert candidate(12) == 2131\n",
       "language": "python"
     },
     {
       "id": 9,
-      "input": "Write a python function to find the minimum number of rotations required to get the same string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the minimum number of rotations required to get the same string.\nYour code should pass this test case: assert find_Rotations(\"aaaa\") == 1",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"aaaa\") == 1\n    assert candidate(\"ab\") == 2\n    assert candidate(\"abc\") == 3\n",
       "language": "python"
     },
     {
       "id": 623,
-      "input": "Write a function to find the n-th power of individual elements in a list using lambda function.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the n-th power of individual elements in a list using lambda function.\nYour code should pass this test case: assert nth_nums([1, 2, 3, 4, 5, 6, 7, 8, 9, 10],2)==[1, 4, 9, 16, 25, 36, 49, 64, 81, 100]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10],2)==[1, 4, 9, 16, 25, 36, 49, 64, 81, 100]\n    assert candidate([10,20,30],3)==([1000, 8000, 27000])\n    assert candidate([12,15],5)==([248832, 759375])\n",
       "language": "python"
     },
     {
       "id": 917,
-      "input": "Write a function to find the sequences of one upper case letter followed by lower case letters.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the sequences of one upper case letter followed by lower case letters.\nYour code should pass this test case: assert text_uppercase_lowercase(\"AaBbGg\")==('Found a match!')",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"AaBbGg\")==('Found a match!')\n    assert candidate(\"aA\")==('Not matched!')\n    assert candidate(\"PYTHON\")==('Not matched!')\n",
       "language": "python"
     },
     {
       "id": 634,
-      "input": "Write a python function to find the sum of fourth power of first n even natural numbers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the sum of fourth power of first n even natural numbers.\nYour code should pass this test case: assert even_Power_Sum(2) == 272",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(2) == 272\n    assert candidate(3) == 1568\n    assert candidate(4) == 5664\n",
       "language": "python"
     },
     {
       "id": 424,
-      "input": "Write a function to extract only the rear index element of each string in the given tuple.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to extract only the rear index element of each string in the given tuple.\nYour code should pass this test case: assert extract_rear(('Mers', 'for', 'Vers') ) == ['s', 'r', 's']",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(('Mers', 'for', 'Vers') ) == ['s', 'r', 's']\n    assert candidate(('Avenge', 'for', 'People') ) == ['e', 'r', 'e']\n    assert candidate(('Gotta', 'get', 'go') ) == ['a', 't', 'o']\n",
       "language": "python"
     },
     {
       "id": 209,
-      "input": "Write a function to delete the smallest element from the given heap and then insert a new item.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to delete the smallest element from the given heap and then insert a new item.\nYour code should pass this test case: assert heap_replace( [25, 44, 68, 21, 39, 23, 89],21)==[21, 25, 23, 44, 39, 68, 89]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate( [25, 44, 68, 21, 39, 23, 89],21)==[21, 25, 23, 44, 39, 68, 89]\n    assert candidate([25, 44, 68, 21, 39, 23, 89],110)== [23, 25, 68, 44, 39, 110, 89]\n    assert candidate([25, 44, 68, 21, 39, 23, 89],500)==[23, 25, 68, 44, 39, 500, 89]\n",
       "language": "python"
     },
     {
       "id": 794,
-      "input": "Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function that matches a string that has an 'a' followed by anything, ending in 'b'.\nYour code should pass this test case: assert text_starta_endb(\"aabbbb\")==('Found a match!')",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"aabbbb\")==('Found a match!')\n    assert candidate(\"aabAbbbc\")==('Not matched!')\n    assert candidate(\"accddbbjjj\")==('Not matched!')\n",
       "language": "python"
     },
     {
       "id": 837,
-      "input": "Write a python function to find the cube sum of first n odd natural numbers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the cube sum of first n odd natural numbers.\nYour code should pass this test case: assert cube_Sum(2) == 28",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(2) == 28\n    assert candidate(3) == 153\n    assert candidate(4) == 496\n",
       "language": "python"
     },
     {
       "id": 628,
-      "input": "Write a function to replace all spaces in the given string with character * list item * list item * list item * list item '%20'.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to replace all spaces in the given string with character * list item * list item * list item * list item '%20'.\nYour code should pass this test case: assert replace_spaces(\"My Name is Dawood\") == 'My%20Name%20is%20Dawood'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"My Name is Dawood\") == 'My%20Name%20is%20Dawood'\n    assert candidate(\"I am a Programmer\") == 'I%20am%20a%20Programmer'\n    assert candidate(\"I love Coding\") == 'I%20love%20Coding'\n",
       "language": "python"
     },
     {
       "id": 190,
-      "input": "Write a python function to count the number of integral co-ordinates that lie inside a square.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count the number of integral co-ordinates that lie inside a square.\nYour code should pass this test case: assert count_Intgral_Points(1,1,4,4) == 4",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(1,1,4,4) == 4\n    assert candidate(1,2,1,2) == 1\n    assert candidate(4,2,6,4) == 1\n",
       "language": "python"
     },
     {
       "id": 570,
-      "input": "Write a function to remove words from a given list of strings containing a character or string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to remove words from a given list of strings containing a character or string.\nYour code should pass this test case: assert remove_words(['Red color', 'Orange#', 'Green', 'Orange @', \"White\"],['#', 'color', '@'])==['Red', '', 'Green', 'Orange', 'White']",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(['Red color', 'Orange#', 'Green', 'Orange @', \"White\"],['#', 'color', '@'])==['Red', '', 'Green', 'Orange', 'White']\n    assert candidate(['Red &', 'Orange+', 'Green', 'Orange @', 'White'],['&', '+', '@'])==['Red', '', 'Green', 'Orange', 'White']\n    assert candidate(['Red &', 'Orange+', 'Green', 'Orange @', 'White'],['@'])==['Red &', 'Orange+', 'Green', 'Orange', 'White']\n",
       "language": "python"
     },
     {
       "id": 299,
-      "input": "Write a function to calculate the maximum aggregate from the list of tuples.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to calculate the maximum aggregate from the list of tuples.\nYour code should pass this test case: assert max_aggregate([('Juan Whelan',90),('Sabah Colley',88),('Peter Nichols',7),('Juan Whelan',122),('Sabah Colley',84)])==('Juan Whelan', 212)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([('Juan Whelan',90),('Sabah Colley',88),('Peter Nichols',7),('Juan Whelan',122),('Sabah Colley',84)])==('Juan Whelan', 212)\n    assert candidate([('Juan Whelan',50),('Sabah Colley',48),('Peter Nichols',37),('Juan Whelan',22),('Sabah Colley',14)])==('Juan Whelan', 72)\n    assert candidate([('Juan Whelan',10),('Sabah Colley',20),('Peter Nichols',30),('Juan Whelan',40),('Sabah Colley',50)])==('Sabah Colley', 70)\n",
       "language": "python"
     },
     {
       "id": 377,
-      "input": "Write a python function to remove all occurrences of a character in a given string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to remove all occurrences of a character in a given string.\nYour code should pass this test case: assert remove_Char(\"aba\",'a') == \"b\"",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"aba\",'a') == \"b\"\n    assert candidate(\"toggle\",'g') == \"tole\"\n    assert candidate(\"aabbc\",'b') == \"aac\"\n",
       "language": "python"
     },
     {
       "id": 537,
-      "input": "Write a python function to find the first repeated word in a given string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the first repeated word in a given string.\nYour code should pass this test case: assert first_repeated_word(\"ab ca bc ab\") == \"ab\"",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"ab ca bc ab\") == \"ab\"\n    assert candidate(\"ab ca bc\") == 'None'\n    assert candidate(\"ab ca bc ca ab bc\") == \"ca\"\n",
       "language": "python"
     },
     {
       "id": 122,
-      "input": "Write a function to find n\u2019th smart number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find n\u2019th smart number.\nYour code should pass this test case: assert smartNumber(1) == 30",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(1) == 30\n    assert candidate(50) == 273\n    assert candidate(1000) == 2664\n",
       "language": "python"
     },
     {
       "id": 317,
-      "input": "Write a function to reflect the modified run-length encoding from a list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to reflect the modified run-length encoding from a list.\nYour code should pass this test case: assert modified_encode([1,1,2,3,4,4,5,1])==[[2, 1], 2, 3, [2, 4], 5, 1]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,1,2,3,4,4,5,1])==[[2, 1], 2, 3, [2, 4], 5, 1]\n    assert candidate('automatically')==['a', 'u', 't', 'o', 'm', 'a', 't', 'i', 'c', 'a', [2, 'l'], 'y']\n    assert candidate('python')==['p', 'y', 't', 'h', 'o', 'n']\n",
       "language": "python"
     },
     {
       "id": 327,
-      "input": "Write a function to print check if the triangle is isosceles or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to print check if the triangle is isosceles or not.\nYour code should pass this test case: assert check_isosceles(6,8,12)==False ",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(6,8,12)==False \n    assert candidate(6,6,12)==True\n    assert candidate(6,16,20)==False\n",
       "language": "python"
     },
     {
       "id": 463,
-      "input": "Write a function to find the maximum product subarray of the given array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the maximum product subarray of the given array.\nYour code should pass this test case: assert max_subarray_product([1, -2, -3, 0, 7, -8, -2]) == 112",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, -2, -3, 0, 7, -8, -2]) == 112\n    assert candidate([6, -3, -10, 0, 2]) == 180 \n    assert candidate([-2, -40, 0, -2, -3]) == 80\n",
       "language": "python"
     },
     {
       "id": 406,
-      "input": "Write a python function to find the parity of a given number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the parity of a given number.\nYour code should pass this test case: assert find_Parity(12) == \"Even Parity\"",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(12) == \"Even Parity\"\n    assert candidate(7) == \"Odd Parity\"\n    assert candidate(10) == \"Even Parity\"\n",
       "language": "python"
     },
     {
       "id": 94,
-      "input": "Write a function to extract the index minimum value record from the given tuples.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to extract the index minimum value record from the given tuples.\nYour code should pass this test case: assert index_minimum([('Rash', 143), ('Manjeet', 200), ('Varsha', 100)]) == 'Varsha'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([('Rash', 143), ('Manjeet', 200), ('Varsha', 100)]) == 'Varsha'\n    assert candidate([('Yash', 185), ('Dawood', 125), ('Sanya', 175)]) == 'Dawood'\n    assert candidate([('Sai', 345), ('Salman', 145), ('Ayesha', 96)]) == 'Ayesha'\n",
       "language": "python"
     },
     {
       "id": 414,
-      "input": "Write a python function to check whether the value exists in a sequence or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether the value exists in a sequence or not.\nYour code should pass this test case: assert overlapping([1,2,3,4,5],[6,7,8,9]) == False",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,3,4,5],[6,7,8,9]) == False\n    assert candidate([1,2,3],[4,5,6]) == False\n    assert candidate([1,4,5],[1,4,5]) == True\n",
       "language": "python"
     },
     {
       "id": 233,
-      "input": "Write a function to find the lateral surface area of a cylinder.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the lateral surface area of a cylinder.\nYour code should pass this test case: assert lateralsuface_cylinder(10,5)==314.15000000000003",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10,5)==314.15000000000003\n    assert candidate(4,5)==125.66000000000001\n    assert candidate(4,10)==251.32000000000002\n",
       "language": "python"
     },
     {
       "id": 60,
-      "input": "Write a function to find the maximum length of the subsequence with difference between adjacent elements for the given array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the maximum length of the subsequence with difference between adjacent elements for the given array.\nYour code should pass this test case: assert max_len_sub([2, 5, 6, 3, 7, 6, 5, 8], 8) == 5",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([2, 5, 6, 3, 7, 6, 5, 8], 8) == 5\n    assert candidate([-2, -1, 5, -1, 4, 0, 3], 7) == 4\n    assert candidate([9, 11, 13, 15, 18], 5) == 1\n",
       "language": "python"
     },
     {
       "id": 733,
-      "input": "Write a function to find the index of the first occurrence of a given number in a sorted array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the index of the first occurrence of a given number in a sorted array.\nYour code should pass this test case: assert find_first_occurrence([2, 5, 5, 5, 6, 6, 8, 9, 9, 9], 5) == 1",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([2, 5, 5, 5, 6, 6, 8, 9, 9, 9], 5) == 1\n    assert candidate([2, 3, 5, 5, 6, 6, 8, 9, 9, 9], 5) == 2\n    assert candidate([2, 4, 1, 5, 6, 6, 8, 9, 9, 9], 6) == 4\n",
       "language": "python"
     },
     {
       "id": 334,
-      "input": "Write a python function to check whether the triangle is valid or not if sides are given.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether the triangle is valid or not if sides are given.\nYour code should pass this test case: assert check_Validity(1,2,3) == False",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(1,2,3) == False\n    assert candidate(2,3,5) == False\n    assert candidate(7,10,5) == True\n",
       "language": "python"
     },
     {
       "id": 737,
-      "input": "Write a function to check whether the given string is starting with a vowel or not using regex.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check whether the given string is starting with a vowel or not using regex.\nYour code should pass this test case: assert check_str(\"annie\") == 'Valid'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"annie\") == 'Valid'\n    assert candidate(\"dawood\") == 'Invalid'\n    assert candidate(\"Else\") == 'Valid'\n",
       "language": "python"
     },
     {
       "id": 932,
-      "input": "Write a function to remove duplicate words from a given list of strings.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to remove duplicate words from a given list of strings.\nYour code should pass this test case: assert remove_duplic_list([\"Python\", \"Exercises\", \"Practice\", \"Solution\", \"Exercises\"])==['Python', 'Exercises', 'Practice', 'Solution']",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([\"Python\", \"Exercises\", \"Practice\", \"Solution\", \"Exercises\"])==['Python', 'Exercises', 'Practice', 'Solution']\n    assert candidate([\"Python\", \"Exercises\", \"Practice\", \"Solution\", \"Exercises\",\"Java\"])==['Python', 'Exercises', 'Practice', 'Solution', 'Java']\n    assert candidate([\"Python\", \"Exercises\", \"Practice\", \"Solution\", \"Exercises\",\"C++\",\"C\",\"C++\"])==['Python', 'Exercises', 'Practice', 'Solution','C++','C']\n",
       "language": "python"
     },
     {
       "id": 522,
-      "input": "Write a function to find the longest bitonic subsequence for the given array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the longest bitonic subsequence for the given array.\nYour code should pass this test case: assert lbs([0 , 8 , 4, 12, 2, 10 , 6 , 14 , 1 , 9 , 5 , 13, 3, 11 , 7 , 15]) == 7",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([0 , 8 , 4, 12, 2, 10 , 6 , 14 , 1 , 9 , 5 , 13, 3, 11 , 7 , 15]) == 7\n    assert candidate([1, 11, 2, 10, 4, 5, 2, 1]) == 6\n    assert candidate([80, 60, 30, 40, 20, 10]) == 5\n",
       "language": "python"
     },
     {
       "id": 695,
-      "input": "Write a function to check if each element of the second tuple is greater than its corresponding index in the first tuple.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check if each element of the second tuple is greater than its corresponding index in the first tuple.\nYour code should pass this test case: assert check_greater((10, 4, 5), (13, 5, 18)) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((10, 4, 5), (13, 5, 18)) == True\n    assert candidate((1, 2, 3), (2, 1, 4)) == False\n    assert candidate((4, 5, 6), (5, 6, 7)) == True\n",
       "language": "python"
     },
     {
       "id": 101,
-      "input": "Write a function to find the kth element in the given array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the kth element in the given array.\nYour code should pass this test case: assert kth_element([12,3,5,7,19], 5, 2) == 3",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([12,3,5,7,19], 5, 2) == 3\n    assert candidate([17,24,8,23], 4, 3) == 8\n    assert candidate([16,21,25,36,4], 5, 4) == 36\n",
       "language": "python"
     },
     {
       "id": 679,
-      "input": "Write a function to access dictionary key\u2019s element by index.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to access dictionary key\u2019s element by index.\nYour code should pass this test case: assert access_key({'physics': 80, 'math': 90, 'chemistry': 86},0)== 'physics'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate({'physics': 80, 'math': 90, 'chemistry': 86},0)== 'physics'\n    assert candidate({'python':10, 'java': 20, 'C++':30},2)== 'C++'\n    assert candidate({'program':15,'computer':45},1)== 'computer'\n",
       "language": "python"
     },
     {
       "id": 289,
-      "input": "Write a python function to calculate the number of odd days in a given year.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to calculate the number of odd days in a given year.\nYour code should pass this test case: assert odd_Days(100) == 5",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(100) == 5\n    assert candidate(50) ==6\n    assert candidate(75) == 2\n",
       "language": "python"
     },
     {
       "id": 45,
-      "input": "Write a function to find the gcd of the given array elements.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the gcd of the given array elements.\nYour code should pass this test case: assert get_gcd([2, 4, 6, 8, 16]) == 2",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([2, 4, 6, 8, 16]) == 2\n    assert candidate([1, 2, 3]) == 1\n    assert candidate([2, 4, 6, 8]) == 2 \n",
       "language": "python"
     },
     {
       "id": 89,
-      "input": "Write a function to find the closest smaller number than n.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the closest smaller number than n.\nYour code should pass this test case: assert closest_num(11) == 10",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(11) == 10\n    assert candidate(7) == 6\n    assert candidate(12) == 11\n",
       "language": "python"
     },
     {
       "id": 664,
-      "input": "Write a python function to find the average of even numbers till a given even number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the average of even numbers till a given even number.\nYour code should pass this test case: assert average_Even(2) == 2",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(2) == 2\n    assert candidate(4) == 3\n    assert candidate(100) == 51\n",
       "language": "python"
     },
     {
       "id": 864,
-      "input": "Write a function to find palindromes in a given list of strings using lambda function.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find palindromes in a given list of strings using lambda function.\nYour code should pass this test case: assert palindrome_lambda([\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\"])==['php', 'aaa']",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([\"php\", \"res\", \"Python\", \"abcd\", \"Java\", \"aaa\"])==['php', 'aaa']\n    assert candidate([\"abcd\", \"Python\", \"abba\", \"aba\"])==['abba', 'aba']\n    assert candidate([\"abcd\", \"abbccbba\", \"abba\", \"aba\"])==['abbccbba', 'abba', 'aba']\n",
       "language": "python"
     },
     {
       "id": 389,
-      "input": "Write a function to find the n'th lucas number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the n'th lucas number.\nYour code should pass this test case: assert find_lucas(9) == 76",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(9) == 76\n    assert candidate(4) == 7\n    assert candidate(3) == 4\n",
       "language": "python"
     },
     {
       "id": 599,
-      "input": "Write a function to find sum and average of first n natural numbers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find sum and average of first n natural numbers.\nYour code should pass this test case: assert sum_average(10)==(55, 5.5)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10)==(55, 5.5)\n    assert candidate(15)==(120, 8.0)\n    assert candidate(20)==(210, 10.5)\n",
       "language": "python"
     },
     {
       "id": 610,
-      "input": "Write a python function to remove the k'th element from a given list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to remove the k'th element from a given list.\nYour code should pass this test case: assert remove_kth_element([1,1,2,3,4,4,5,1],3)==[1, 1, 3, 4, 4, 5, 1]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,1,2,3,4,4,5,1],3)==[1, 1, 3, 4, 4, 5, 1]\n    assert candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4],4)==[0, 0, 1, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4]\n    assert candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10],5)==[10,10,15,19, 18, 17, 26, 26, 17, 18, 10]\n",
       "language": "python"
     },
     {
       "id": 295,
-      "input": "Write a function to return the sum of all divisors of a number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to return the sum of all divisors of a number.\nYour code should pass this test case: assert sum_div(8)==7",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(8)==7\n    assert candidate(12)==16\n    assert candidate(7)==1\n",
       "language": "python"
     },
     {
       "id": 326,
-      "input": "Write a function to get the word with most number of occurrences in the given strings list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to get the word with most number of occurrences in the given strings list.\nYour code should pass this test case: assert most_occurrences([\"UTS is best for RTF\", \"RTF love UTS\", \"UTS is best\"] ) == 'UTS'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([\"UTS is best for RTF\", \"RTF love UTS\", \"UTS is best\"] ) == 'UTS'\n    assert candidate([\"Its been a great year\", \"this year is so worse\", \"this year is okay\"] ) == 'year'\n    assert candidate([\"Families can be reunited\", \"people can be reunited\", \"Tasks can be achieved \"] ) == 'can'\n",
       "language": "python"
     },
     {
       "id": 846,
-      "input": "Write a function to find the minimum number of platforms required for a railway/bus station.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the minimum number of platforms required for a railway/bus station.\nYour code should pass this test case: assert find_platform([900, 940, 950, 1100, 1500, 1800],[910, 1200, 1120, 1130, 1900, 2000],6)==3",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([900, 940, 950, 1100, 1500, 1800],[910, 1200, 1120, 1130, 1900, 2000],6)==3\n    assert candidate([100,200,300,400],[700,800,900,1000],4)==4\n    assert candidate([5,6,7,8],[4,3,2,1],4)==1\n",
       "language": "python"
     },
     {
       "id": 376,
-      "input": "Write a function to remove tuple elements that occur more than once and replace the duplicates with some custom value.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to remove tuple elements that occur more than once and replace the duplicates with some custom value.\nYour code should pass this test case: assert remove_replica((1, 1, 4, 4, 4, 5, 5, 6, 7, 7)) == (1, 'MSP', 4, 'MSP', 'MSP', 5, 'MSP', 6, 7, 'MSP')",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((1, 1, 4, 4, 4, 5, 5, 6, 7, 7)) == (1, 'MSP', 4, 'MSP', 'MSP', 5, 'MSP', 6, 7, 'MSP')\n    assert candidate((2, 3, 4, 4, 5, 6, 6, 7, 8, 9, 9)) == (2, 3, 4, 'MSP', 5, 6, 'MSP', 7, 8, 9, 'MSP')\n    assert candidate((2, 2, 5, 4, 5, 7, 5, 6, 7, 7)) == (2, 'MSP', 5, 4, 'MSP', 7, 'MSP', 6, 'MSP', 'MSP')\n",
       "language": "python"
     },
     {
       "id": 445,
-      "input": "Write a function to perform index wise multiplication of tuple elements in the given two tuples.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to perform index wise multiplication of tuple elements in the given two tuples.\nYour code should pass this test case: assert index_multiplication(((1, 3), (4, 5), (2, 9), (1, 10)),((6, 7), (3, 9), (1, 1), (7, 3)) ) == ((6, 21), (12, 45), (2, 9), (7, 30))",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(((1, 3), (4, 5), (2, 9), (1, 10)),((6, 7), (3, 9), (1, 1), (7, 3)) ) == ((6, 21), (12, 45), (2, 9), (7, 30))\n    assert candidate(((2, 4), (5, 6), (3, 10), (2, 11)),((7, 8), (4, 10), (2, 2), (8, 4)) ) == ((14, 32), (20, 60), (6, 20), (16, 44))\n    assert candidate(((3, 5), (6, 7), (4, 11), (3, 12)),((8, 9), (5, 11), (3, 3), (9, 5)) ) == ((24, 45), (30, 77), (12, 33), (27, 60))\n",
       "language": "python"
     },
     {
       "id": 450,
-      "input": "Write a function to extract specified size of strings from a give list of string values.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to extract specified size of strings from a give list of string values.\nYour code should pass this test case: assert extract_string(['Python', 'list', 'exercises', 'practice', 'solution'] ,8)==['practice', 'solution']",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(['Python', 'list', 'exercises', 'practice', 'solution'] ,8)==['practice', 'solution']\n    assert candidate(['Python', 'list', 'exercises', 'practice', 'solution'] ,6)==['Python']\n    assert candidate(['Python', 'list', 'exercises', 'practice', 'solution'] ,9)==['exercises']\n",
       "language": "python"
     },
     {
       "id": 807,
-      "input": "Write a python function to find the first odd number in a given list of numbers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the first odd number in a given list of numbers.\nYour code should pass this test case: assert first_odd([1,3,5]) == 1",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,3,5]) == 1\n    assert candidate([2,4,1,3]) == 1\n    assert candidate([8,9,1]) == 9\n",
       "language": "python"
     },
     {
       "id": 304,
-      "input": "Write a python function to find element at a given index after number of rotations.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find element at a given index after number of rotations.\nYour code should pass this test case: assert find_Element([1,2,3,4,5],[[0,2],[0,3]],2,1) == 3",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,3,4,5],[[0,2],[0,3]],2,1) == 3\n    assert candidate([1,2,3,4],[[0,1],[0,2]],1,2) == 3\n    assert candidate([1,2,3,4,5,6],[[0,1],[0,2]],1,1) == 1\n",
       "language": "python"
     },
     {
       "id": 367,
-      "input": "Write a function to check if a binary tree is balanced or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check if a binary tree is balanced or not.\nYour code should pass this test case: assert is_tree_balanced(root) == False",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(root) == False\n    assert candidate(root1) == True\n    assert candidate(root2) == False \n",
       "language": "python"
     },
     {
       "id": 255,
-      "input": "Write a function to choose specified number of colours from three different colours and generate all the combinations with repetitions.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to choose specified number of colours from three different colours and generate all the combinations with repetitions.\nYour code should pass this test case: assert combinations_colors( [\"Red\",\"Green\",\"Blue\"],1)==[('Red',), ('Green',), ('Blue',)]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate( [\"Red\",\"Green\",\"Blue\"],1)==[('Red',), ('Green',), ('Blue',)]\n    assert candidate( [\"Red\",\"Green\",\"Blue\"],2)==[('Red', 'Red'), ('Red', 'Green'), ('Red', 'Blue'), ('Green', 'Green'), ('Green', 'Blue'), ('Blue', 'Blue')]\n    assert candidate( [\"Red\",\"Green\",\"Blue\"],3)==[('Red', 'Red', 'Red'), ('Red', 'Red', 'Green'), ('Red', 'Red', 'Blue'), ('Red', 'Green', 'Green'), ('Red', 'Green', 'Blue'), ('Red', 'Blue', 'Blue'), ('Green', 'Green', 'Green'), ('Green', 'Green', 'Blue'), ('Green', 'Blue', 'Blue'), ('Blue', 'Blue', 'Blue')]\n",
       "language": "python"
     },
     {
       "id": 504,
-      "input": "Write a python function to find the cube sum of first n natural numbers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the cube sum of first n natural numbers.\nYour code should pass this test case: assert sum_Of_Series(5) == 225",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(5) == 225\n    assert candidate(2) == 9\n    assert candidate(3) == 36\n",
       "language": "python"
     },
     {
       "id": 745,
-      "input": "Write a function to find numbers within a given range where every number is divisible by every digit it contains.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find numbers within a given range where every number is divisible by every digit it contains.\nYour code should pass this test case: assert divisible_by_digits(1,22)==[1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(1,22)==[1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15, 22]\n    assert candidate(1,15)==[1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 15]\n    assert candidate(20,25)==[22, 24]\n",
       "language": "python"
     },
     {
       "id": 505,
-      "input": "Write a function to move all zeroes to the end of the given array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to move all zeroes to the end of the given array.\nYour code should pass this test case: assert re_order([6, 0, 8, 2, 3, 0, 4, 0, 1]) == [6, 8, 2, 3, 4, 1, 0, 0, 0]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([6, 0, 8, 2, 3, 0, 4, 0, 1]) == [6, 8, 2, 3, 4, 1, 0, 0, 0]\n    assert candidate([4, 0, 2, 7, 0, 9, 0, 12, 0]) == [4, 2, 7, 9, 12, 0, 0, 0, 0]\n    assert candidate([3, 11, 0, 74, 14, 0, 1, 0, 2]) == [3, 11, 74, 14, 1, 2, 0, 0, 0]\n",
       "language": "python"
     },
     {
       "id": 501,
-      "input": "Write a python function to find common divisor between two numbers in a given pair.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find common divisor between two numbers in a given pair.\nYour code should pass this test case: assert num_comm_div(2,4) == 2",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(2,4) == 2\n    assert candidate(2,8) == 2\n    assert candidate(12,24) == 6\n",
       "language": "python"
     },
     {
       "id": 162,
-      "input": "Write a function to calculate the sum of the positive integers of n+(n-2)+(n-4)... (until n-x =< 0).",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to calculate the sum of the positive integers of n+(n-2)+(n-4)... (until n-x =< 0).\nYour code should pass this test case: assert sum_series(6)==12",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(6)==12\n    assert candidate(10)==30\n    assert candidate(9)==25\n",
       "language": "python"
     },
     {
       "id": 458,
-      "input": "Write a function to find the area of a rectangle.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the area of a rectangle.\nYour code should pass this test case: assert rectangle_area(10,20)==200",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10,20)==200\n    assert candidate(10,5)==50\n    assert candidate(4,2)==8\n",
       "language": "python"
     },
     {
       "id": 594,
-      "input": "Write a function to find the difference of first even and odd number of a given list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the difference of first even and odd number of a given list.\nYour code should pass this test case: assert diff_even_odd([1,3,5,7,4,1,6,8])==3",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,3,5,7,4,1,6,8])==3\n    assert candidate([1,2,3,4,5,6,7,8,9,10])==1\n    assert candidate([1,5,7,9,10])==9\n",
       "language": "python"
     },
     {
       "id": 827,
-      "input": "Write a function to sum a specific column of a list in a given list of lists.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to sum a specific column of a list in a given list of lists.\nYour code should pass this test case: assert sum_column( [[1,2,3,2],[4,5,6,2],[7,8,9,5],],0)==12",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate( [[1,2,3,2],[4,5,6,2],[7,8,9,5],],0)==12\n    assert candidate( [[1,2,3,2],[4,5,6,2],[7,8,9,5],],1)==15\n    assert candidate( [[1,2,3,2],[4,5,6,2],[7,8,9,5],],3)==9\n",
       "language": "python"
     },
     {
       "id": 937,
-      "input": "Write a function to count the most common character in a given string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to count the most common character in a given string.\nYour code should pass this test case: assert max_char(\"hello world\")==('l')",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"hello world\")==('l')\n    assert candidate(\"hello \")==('l')\n    assert candidate(\"python pr\")==('p')\n",
       "language": "python"
     },
     {
       "id": 123,
-      "input": "Write a function to sum all amicable numbers from 1 to a specified number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to sum all amicable numbers from 1 to a specified number.\nYour code should pass this test case: assert amicable_numbers_sum(999)==504",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(999)==504\n    assert candidate(9999)==31626\n    assert candidate(99)==0\n",
       "language": "python"
     },
     {
       "id": 417,
-      "input": "Write a function to find common first element in given list of tuple.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find common first element in given list of tuple.\nYour code should pass this test case: assert group_tuples([('x', 'y'), ('x', 'z'), ('w', 't')]) == [('x', 'y', 'z'), ('w', 't')]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([('x', 'y'), ('x', 'z'), ('w', 't')]) == [('x', 'y', 'z'), ('w', 't')]\n    assert candidate([('a', 'b'), ('a', 'c'), ('d', 'e')]) == [('a', 'b', 'c'), ('d', 'e')]\n    assert candidate([('f', 'g'), ('f', 'g'), ('h', 'i')]) == [('f', 'g', 'g'), ('h', 'i')]\n",
       "language": "python"
     },
     {
       "id": 622,
-      "input": "Write a function to find the median of two sorted arrays of same size.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the median of two sorted arrays of same size.\nYour code should pass this test case: assert get_median([1, 12, 15, 26, 38], [2, 13, 17, 30, 45], 5) == 16.0",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 12, 15, 26, 38], [2, 13, 17, 30, 45], 5) == 16.0\n    assert candidate([2, 4, 8, 9], [7, 13, 19, 28], 4) == 8.5\n    assert candidate([3, 6, 14, 23, 36, 42], [2, 18, 27, 39, 49, 55], 6) == 25.0\n",
       "language": "python"
     },
     {
       "id": 940,
-      "input": "Write a function to sort the given array by using heap sort.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to sort the given array by using heap sort.\nYour code should pass this test case: assert heap_sort([12, 2, 4, 5, 2, 3]) == [2, 2, 3, 4, 5, 12]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([12, 2, 4, 5, 2, 3]) == [2, 2, 3, 4, 5, 12]\n    assert candidate([32, 14, 5, 6, 7, 19]) == [5, 6, 7, 14, 19, 32]\n    assert candidate([21, 15, 29, 78, 65]) == [15, 21, 29, 65, 78]\n",
       "language": "python"
     },
     {
       "id": 947,
-      "input": "Write a python function to find the length of the shortest word.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the length of the shortest word.\nYour code should pass this test case: assert len_log([\"win\",\"lose\",\"great\"]) == 3",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([\"win\",\"lose\",\"great\"]) == 3\n    assert candidate([\"a\",\"ab\",\"abc\"]) == 1\n    assert candidate([\"12\",\"12\",\"1234\"]) == 2\n",
       "language": "python"
     },
     {
       "id": 41,
-      "input": "Write a function to filter even numbers using lambda function.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to filter even numbers using lambda function.\nYour code should pass this test case: assert filter_evennumbers([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])==[2, 4, 6, 8, 10]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])==[2, 4, 6, 8, 10]\n    assert candidate([10,20,45,67,84,93])==[10,20,84]\n    assert candidate([5,7,9,8,6,4,3])==[8,6,4]\n",
       "language": "python"
     },
     {
       "id": 524,
-      "input": "Write a function to find the sum of maximum increasing subsequence of the given array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the sum of maximum increasing subsequence of the given array.\nYour code should pass this test case: assert max_sum_increasing_subsequence([1, 101, 2, 3, 100, 4, 5], 7) == 106",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 101, 2, 3, 100, 4, 5], 7) == 106\n    assert candidate([3, 4, 5, 10], 4) == 22\n    assert candidate([10, 5, 4, 3], 4) == 10\n",
       "language": "python"
     },
     {
       "id": 547,
-      "input": "Write a python function to find the sum of hamming distances of all consecutive numbers from o to n.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the sum of hamming distances of all consecutive numbers from o to n.\nYour code should pass this test case: assert Total_Hamming_Distance(4) == 7",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(4) == 7\n    assert candidate(2) == 3\n    assert candidate(5) == 8\n",
       "language": "python"
     },
     {
       "id": 341,
-      "input": "Write a function to convert the given set into ordered tuples.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to convert the given set into ordered tuples.\nYour code should pass this test case: assert set_to_tuple({1, 2, 3, 4, 5}) == (1, 2, 3, 4, 5)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate({1, 2, 3, 4, 5}) == (1, 2, 3, 4, 5)\n    assert candidate({6, 7, 8, 9, 10, 11}) == (6, 7, 8, 9, 10, 11)\n    assert candidate({12, 13, 14, 15, 16}) == (12, 13, 14, 15, 16)\n",
       "language": "python"
     },
     {
       "id": 351,
-      "input": "Write a python function to find the first element occurring k times in a given array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the first element occurring k times in a given array.\nYour code should pass this test case: assert first_Element([0,1,2,3,4,5],6,1) == 0",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([0,1,2,3,4,5],6,1) == 0\n    assert candidate([1,2,1,3,4],5,2) == 1\n    assert candidate([2,3,4,3,5,7,1,2,3,5],10,2) == 2\n",
       "language": "python"
     },
     {
       "id": 944,
-      "input": "Write a function to separate and print the numbers and their position of a given string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to separate and print the numbers and their position of a given string.\nYour code should pass this test case: assert num_position(\"there are 70 flats in this apartment\")==10",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"there are 70 flats in this apartment\")==10\n    assert candidate(\"every adult have 32 teeth\")==17\n    assert candidate(\"isha has 79 chocolates in her bag\")==9\n",
       "language": "python"
     },
     {
       "id": 438,
-      "input": "Write a function to count bidirectional tuple pairs.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to count bidirectional tuple pairs.\nYour code should pass this test case: assert count_bidirectional([(5, 6), (1, 2), (6, 5), (9, 1), (6, 5), (2, 1)] ) == '3'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([(5, 6), (1, 2), (6, 5), (9, 1), (6, 5), (2, 1)] ) == '3'\n    assert candidate([(5, 6), (1, 3), (6, 5), (9, 1), (6, 5), (2, 1)] ) == '2'\n    assert candidate([(5, 6), (1, 2), (6, 5), (9, 2), (6, 5), (2, 1)] ) == '4'\n",
       "language": "python"
     },
     {
       "id": 191,
-      "input": "Write a function to check whether the given month name contains 30 days or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check whether the given month name contains 30 days or not.\nYour code should pass this test case: assert check_monthnumber(\"February\")==False",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"February\")==False\n    assert candidate(\"June\")==True\n    assert candidate(\"April\")==True\n",
       "language": "python"
     },
     {
       "id": 362,
-      "input": "Write a python function to find the item with maximum occurrences in a given list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the item with maximum occurrences in a given list.\nYour code should pass this test case: assert max_occurrences([1,2,3,1,2,3,12,4,2]) ==  2",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,3,1,2,3,12,4,2]) ==  2\n    assert candidate([1,2,6,7,0,1,0,1,0]) == 1,0\n    assert candidate([1,2,3,1,2,4,1]) == 1\n",
       "language": "python"
     },
     {
       "id": 798,
-      "input": "Write a python function to find the sum of an array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the sum of an array.\nYour code should pass this test case: assert _sum([1, 2, 3]) == 6",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 2, 3]) == 6\n    assert candidate([15, 12, 13, 10]) == 50\n    assert candidate([0, 1, 2]) == 3\n",
       "language": "python"
     },
     {
       "id": 125,
-      "input": "Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the maximum difference between the number of 0s and number of 1s in any sub-string of the given binary string.\nYour code should pass this test case: assert find_length(\"11000010001\", 11) == 6",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"11000010001\", 11) == 6\n    assert candidate(\"10111\", 5) == 1\n    assert candidate(\"11011101100101\", 14) == 2 \n",
       "language": "python"
     },
     {
       "id": 861,
-      "input": "Write a function to find all anagrams of a string in a given list of strings using lambda function.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find all anagrams of a string in a given list of strings using lambda function.\nYour code should pass this test case: assert anagram_lambda([\"bcda\", \"abce\", \"cbda\", \"cbea\", \"adcb\"],\"abcd\")==['bcda', 'cbda', 'adcb']",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([\"bcda\", \"abce\", \"cbda\", \"cbea\", \"adcb\"],\"abcd\")==['bcda', 'cbda', 'adcb']\n    assert candidate([\"recitals\",\" python\"], \"articles\" )==[\"recitals\"]\n    assert candidate([\" keep\",\" abcdef\",\" xyz\"],\" peek\")==[\" keep\"]\n",
       "language": "python"
     },
     {
       "id": 67,
-      "input": "Write a function to find the number of ways to partition a set of bell numbers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the number of ways to partition a set of bell numbers.\nYour code should pass this test case: assert bell_number(2)==2",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(2)==2\n    assert candidate(10)==115975\n    assert candidate(56)==6775685320645824322581483068371419745979053216268760300\n",
       "language": "python"
     },
     {
       "id": 256,
-      "input": "Write a python function to count the number of prime numbers less than a given non-negative number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count the number of prime numbers less than a given non-negative number.\nYour code should pass this test case: assert count_Primes_nums(5) == 2",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(5) == 2\n    assert candidate(10) == 4\n    assert candidate(100) == 25\n",
       "language": "python"
     },
     {
       "id": 796,
-      "input": "Write function to find the sum of all items in the given dictionary.",
+      "input": "You are an expert Python programmer, and here is your task: Write function to find the sum of all items in the given dictionary.\nYour code should pass this test case: assert return_sum({'a': 100, 'b':200, 'c':300}) == 600",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate({'a': 100, 'b':200, 'c':300}) == 600\n    assert candidate({'a': 25, 'b':18, 'c':45}) == 88\n    assert candidate({'a': 36, 'b':39, 'c':49}) == 124\n",
       "language": "python"
     },
     {
       "id": 449,
-      "input": "Write a python function to check whether the triangle is valid or not if 3 points are given.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check whether the triangle is valid or not if 3 points are given.\nYour code should pass this test case: assert check_Triangle(1,5,2,5,4,6) == 'Yes'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(1,5,2,5,4,6) == 'Yes'\n    assert candidate(1,1,1,4,1,5) == 'No'\n    assert candidate(1,1,1,1,1,1) == 'No'\n",
       "language": "python"
     },
     {
       "id": 378,
-      "input": "Write a python function to shift last element to first position in the given list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to shift last element to first position in the given list.\nYour code should pass this test case: assert move_first([1,2,3,4]) == [4,1,2,3]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,3,4]) == [4,1,2,3]\n    assert candidate([0,1,2,3]) == [3,0,1,2]\n    assert candidate([9,8,7,1]) == [1,9,8,7]\n",
       "language": "python"
     },
     {
       "id": 926,
-      "input": "Write a function to find n-th rencontres number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find n-th rencontres number.\nYour code should pass this test case: assert rencontres_number(7, 2) == 924",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(7, 2) == 924\n    assert candidate(3, 0) == 2\n    assert candidate(3, 1) == 3\n",
       "language": "python"
     },
     {
       "id": 767,
-      "input": "Write a python function to count the number of pairs whose sum is equal to \u2018sum\u2019.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count the number of pairs whose sum is equal to \u2018sum\u2019.\nYour code should pass this test case: assert get_Pairs_Count([1,1,1,1],4,2) == 6",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,1,1,1],4,2) == 6\n    assert candidate([1,5,7,-1,5],5,6) == 3\n    assert candidate([1,-2,3],3,1) == 1\n",
       "language": "python"
     },
     {
       "id": 541,
-      "input": "Write a function to find if the given number is abundant or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find if the given number is abundant or not.\nYour code should pass this test case: assert check_abundant(12) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(12) == True\n    assert candidate(15) == False\n    assert candidate(18) == True\n",
       "language": "python"
     },
     {
       "id": 825,
-      "input": "Write a python function to access multiple elements of specified index from a given list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to access multiple elements of specified index from a given list.\nYour code should pass this test case: assert access_elements([2,3,8,4,7,9],[0,3,5]) == [2, 4, 9]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([2,3,8,4,7,9],[0,3,5]) == [2, 4, 9]\n    assert candidate([1, 2, 3, 4, 5],[1,2]) == [2,3]\n    assert candidate([1,0,2,3],[0,1]) == [1,0]\n",
       "language": "python"
     },
     {
       "id": 385,
-      "input": "Write a function to find the n'th perrin number using recursion.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the n'th perrin number using recursion.\nYour code should pass this test case: assert get_perrin(9) == 12",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(9) == 12\n    assert candidate(4) == 2\n    assert candidate(6) == 5\n",
       "language": "python"
     },
     {
       "id": 452,
-      "input": "Write a function that gives loss amount if the given amount has loss else return none.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function that gives loss amount if the given amount has loss else return none.\nYour code should pass this test case: assert loss_amount(1500,1200)==None",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(1500,1200)==None\n    assert candidate(100,200)==100\n    assert candidate(2000,5000)==3000\n",
       "language": "python"
     },
     {
       "id": 529,
-      "input": "Write a function to find the nth jacobsthal-lucas number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the nth jacobsthal-lucas number.\nYour code should pass this test case: assert jacobsthal_lucas(5) == 31",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(5) == 31\n    assert candidate(2) == 5\n    assert candidate(4) == 17\n",
       "language": "python"
     },
     {
       "id": 663,
-      "input": "Write a function to find the largest possible value of k such that k modulo x is y.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the largest possible value of k such that k modulo x is y.\nYour code should pass this test case: assert find_max_val(15, 10, 5) == 15",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(15, 10, 5) == 15\n    assert candidate(187, 10, 5) == 185\n    assert candidate(16, 11, 1) == 12\n",
       "language": "python"
     },
     {
       "id": 747,
-      "input": "Write a function to find the longest common subsequence for the given three string sequence.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the longest common subsequence for the given three string sequence.\nYour code should pass this test case: assert lcs_of_three('AGGT12', '12TXAYB', '12XBA', 6, 7, 5) == 2",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('AGGT12', '12TXAYB', '12XBA', 6, 7, 5) == 2\n    assert candidate('Reels', 'Reelsfor', 'ReelsforReels', 5, 8, 13) == 5 \n    assert candidate('abcd1e2', 'bc12ea', 'bd1ea', 7, 6, 5) == 3\n",
       "language": "python"
     },
     {
       "id": 24,
-      "input": "Write a function to convert the given binary number to its decimal equivalent.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to convert the given binary number to its decimal equivalent.\nYour code should pass this test case: assert binary_to_decimal(100) == 4",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(100) == 4\n    assert candidate(1011) == 11\n    assert candidate(1101101) == 109\n",
       "language": "python"
     },
     {
       "id": 104,
-      "input": "Write a function to sort each sublist of strings in a given list of lists using lambda function.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to sort each sublist of strings in a given list of lists using lambda function.\nYour code should pass this test case: assert sort_sublists(([\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]))==[['green', 'orange'], ['black', 'white'], ['black', 'orange', 'white']]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(([\"green\", \"orange\"], [\"black\", \"white\"], [\"white\", \"black\", \"orange\"]))==[['green', 'orange'], ['black', 'white'], ['black', 'orange', 'white']]\n    assert candidate(([\" red \",\"green\" ],[\"blue \",\" black\"],[\" orange\",\"brown\"]))==[[' red ', 'green'], [' black', 'blue '], [' orange', 'brown']]\n    assert candidate(([\"zilver\",\"gold\"], [\"magnesium\",\"aluminium\"], [\"steel\", \"bronze\"]))==[['gold', 'zilver'],['aluminium', 'magnesium'], ['bronze', 'steel']]\n",
       "language": "python"
     },
     {
       "id": 613,
-      "input": "Write a function to find the maximum value in record list as tuple attribute in the given tuple list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the maximum value in record list as tuple attribute in the given tuple list.\nYour code should pass this test case: assert maximum_value([('key1', [3, 4, 5]), ('key2', [1, 4, 2]), ('key3', [9, 3])]) == [('key1', 5), ('key2', 4), ('key3', 9)]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([('key1', [3, 4, 5]), ('key2', [1, 4, 2]), ('key3', [9, 3])]) == [('key1', 5), ('key2', 4), ('key3', 9)]\n    assert candidate([('key1', [4, 5, 6]), ('key2', [2, 5, 3]), ('key3', [10, 4])]) == [('key1', 6), ('key2', 5), ('key3', 10)]\n    assert candidate([('key1', [5, 6, 7]), ('key2', [3, 6, 4]), ('key3', [11, 5])]) == [('key1', 7), ('key2', 6), ('key3', 11)]\n",
       "language": "python"
     },
     {
       "id": 467,
-      "input": "Write a python function to convert decimal number to octal number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to convert decimal number to octal number.\nYour code should pass this test case: assert decimal_to_Octal(10) == 12",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10) == 12\n    assert candidate(2) == 2\n    assert candidate(33) == 41\n",
       "language": "python"
     },
     {
       "id": 565,
-      "input": "Write a python function to split a string into characters.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to split a string into characters.\nYour code should pass this test case: assert split('python') == ['p','y','t','h','o','n']",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('python') == ['p','y','t','h','o','n']\n    assert candidate('Name') == ['N','a','m','e']\n    assert candidate('program') == ['p','r','o','g','r','a','m']\n",
       "language": "python"
     },
     {
       "id": 98,
-      "input": "Write a function to multiply all the numbers in a list and divide with the length of the list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to multiply all the numbers in a list and divide with the length of the list.\nYour code should pass this test case: assert multiply_num((8, 2, 3, -1, 7))==-67.2",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((8, 2, 3, -1, 7))==-67.2\n    assert candidate((-10,-20,-30))==-2000.0\n    assert candidate((19,15,18))==1710.0\n",
       "language": "python"
     },
     {
       "id": 152,
-      "input": "Write a function to sort the given array by using merge sort.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to sort the given array by using merge sort.\nYour code should pass this test case: assert merge_sort([3, 4, 2, 6, 5, 7, 1, 9]) == [1, 2, 3, 4, 5, 6, 7, 9]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([3, 4, 2, 6, 5, 7, 1, 9]) == [1, 2, 3, 4, 5, 6, 7, 9]\n    assert candidate([7, 25, 45, 78, 11, 33, 19]) == [7, 11, 19, 25, 33, 45, 78]\n    assert candidate([3, 1, 4, 9, 8]) == [1, 3, 4, 8, 9]\n",
       "language": "python"
     },
     {
       "id": 172,
-      "input": "Write a function to find the occurence of characters 'std' in the given string 1. list item 1. list item 1. list item 2. list item 2. list item 2. list item",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the occurence of characters 'std' in the given string 1. list item 1. list item 1. list item 2. list item 2. list item 2. list item\nYour code should pass this test case: assert count_occurance(\"letstdlenstdporstd\") == 3",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"letstdlenstdporstd\") == 3\n    assert candidate(\"truststdsolensporsd\") == 1\n    assert candidate(\"makestdsostdworthit\") == 2\n",
       "language": "python"
     },
     {
       "id": 615,
-      "input": "Write a function to find average value of the numbers in a given tuple of tuples.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find average value of the numbers in a given tuple of tuples.\nYour code should pass this test case: assert average_tuple(((10, 10, 10, 12), (30, 45, 56, 45), (81, 80, 39, 32), (1, 2, 3, 4)))==[30.5, 34.25, 27.0, 23.25]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(((10, 10, 10, 12), (30, 45, 56, 45), (81, 80, 39, 32), (1, 2, 3, 4)))==[30.5, 34.25, 27.0, 23.25]\n    assert candidate(((1, 1, -5), (30, -15, 56), (81, -60, -39), (-10, 2, 3)))== [25.5, -18.0, 3.75]\n    assert candidate( ((100, 100, 100, 120), (300, 450, 560, 450), (810, 800, 390, 320), (10, 20, 30, 40)))==[305.0, 342.5, 270.0, 232.5]\n",
       "language": "python"
     },
     {
       "id": 383,
-      "input": "Write a python function to toggle all odd bits of a given number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to toggle all odd bits of a given number.\nYour code should pass this test case: assert even_bit_toggle_number(10) == 15",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10) == 15\n    assert candidate(20) == 1\n    assert candidate(30) == 11\n",
       "language": "python"
     },
     {
       "id": 350,
-      "input": "Write a python function to minimize the length of the string by removing occurrence of only one character.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to minimize the length of the string by removing occurrence of only one character.\nYour code should pass this test case: assert minimum_Length(\"mnm\") == 1",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"mnm\") == 1\n    assert candidate(\"abcda\") == 3\n    assert candidate(\"abcb\") == 2\n",
       "language": "python"
     },
     {
       "id": 23,
-      "input": "Write a python function to find the maximum sum of elements of list in a list of lists.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the maximum sum of elements of list in a list of lists.\nYour code should pass this test case: assert maximum_Sum([[1,2,3],[4,5,6],[10,11,12],[7,8,9]]) == 33",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[1,2,3],[4,5,6],[10,11,12],[7,8,9]]) == 33\n    assert candidate([[0,1,1],[1,1,2],[3,2,1]]) == 6\n    assert candidate([[0,1,3],[1,2,1],[9,8,2],[0,1,0],[6,4,8]]) == 19\n    assert candidate([[0,-1,-1],[-1,-1,-2],[-3,-2,-1]]) == -2\n",
       "language": "python"
     },
     {
       "id": 120,
-      "input": "Write a function to find the maximum product from the pairs of tuples within a given list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the maximum product from the pairs of tuples within a given list.\nYour code should pass this test case: assert max_product_tuple([(2, 7), (2, 6), (1, 8), (4, 9)] )==36",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([(2, 7), (2, 6), (1, 8), (4, 9)] )==36\n    assert candidate([(10,20), (15,2), (5,10)] )==200\n    assert candidate([(11,44), (10,15), (20,5), (12, 9)] )==484\n",
       "language": "python"
     },
     {
       "id": 46,
-      "input": "Write a python function to determine whether all the numbers are different from each other are not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to determine whether all the numbers are different from each other are not.\nYour code should pass this test case: assert test_distinct([1,5,7,9]) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,5,7,9]) == True\n    assert candidate([2,4,5,5,7,9]) == False\n    assert candidate([1,2,3]) == True\n",
       "language": "python"
     },
     {
       "id": 446,
-      "input": "Write a python function to count the occurence of all elements of list in a tuple.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count the occurence of all elements of list in a tuple.\nYour code should pass this test case: assert count_Occurrence(('a', 'a', 'c', 'b', 'd'),['a', 'b'] ) == 3",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(('a', 'a', 'c', 'b', 'd'),['a', 'b'] ) == 3\n    assert candidate((1, 2, 3, 1, 4, 6, 7, 1, 4),[1, 4, 7]) == 6\n    assert candidate((1,2,3,4,5,6),[1,2]) == 2\n",
       "language": "python"
     },
     {
       "id": 375,
-      "input": "Write a function to round the given number to the nearest multiple of a specific number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to round the given number to the nearest multiple of a specific number.\nYour code should pass this test case: assert round_num(4722,10)==4720",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(4722,10)==4720\n    assert candidate(1111,5)==1110\n    assert candidate(219,2)==218\n",
       "language": "python"
     },
     {
       "id": 656,
-      "input": "Write a python function to find the minimum sum of absolute differences of two arrays.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the minimum sum of absolute differences of two arrays.\nYour code should pass this test case: assert find_Min_Sum([3,2,1],[2,1,3],3) == 0",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([3,2,1],[2,1,3],3) == 0\n    assert candidate([1,2,3],[4,5,6],3) == 9\n    assert candidate([4,1,8,7],[2,3,6,5],4) == 6\n",
       "language": "python"
     },
     {
       "id": 141,
-      "input": "Write a function to sort a list of elements using pancake sort.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to sort a list of elements using pancake sort.\nYour code should pass this test case: assert pancake_sort([15, 79, 25, 38, 69]) == [15, 25, 38, 69, 79]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([15, 79, 25, 38, 69]) == [15, 25, 38, 69, 79]\n    assert candidate([98, 12, 54, 36, 85]) == [12, 36, 54, 85, 98]\n    assert candidate([41, 42, 32, 12, 23]) == [12, 23, 32, 41, 42]\n",
       "language": "python"
     },
     {
       "id": 130,
-      "input": "Write a function to find the item with maximum frequency in a given list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the item with maximum frequency in a given list.\nYour code should pass this test case: assert max_occurrences([2,3,8,4,7,9,8,2,6,5,1,6,1,2,3,2,4,6,9,1,2])==(2, 5)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([2,3,8,4,7,9,8,2,6,5,1,6,1,2,3,2,4,6,9,1,2])==(2, 5)\n    assert candidate([2,3,8,4,7,9,8,7,9,15,14,10,12,13,16,16,18])==(8, 2)\n    assert candidate([10,20,20,30,40,90,80,50,30,20,50,10])==(20, 3)\n",
       "language": "python"
     },
     {
       "id": 479,
-      "input": "Write a python function to find the first digit of a given number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the first digit of a given number.\nYour code should pass this test case: assert first_Digit(123) == 1",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(123) == 1\n    assert candidate(456) == 4\n    assert candidate(12) == 1\n",
       "language": "python"
     },
     {
       "id": 816,
-      "input": "Write a function to clear the values of the given tuples.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to clear the values of the given tuples.\nYour code should pass this test case: assert clear_tuple((1, 5, 3, 6, 8)) == ()",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((1, 5, 3, 6, 8)) == ()\n    assert candidate((2, 1, 4 ,5 ,6)) == ()\n    assert candidate((3, 2, 5, 6, 8)) == ()\n",
       "language": "python"
     },
     {
       "id": 257,
-      "input": "Write a function to swap two numbers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to swap two numbers.\nYour code should pass this test case: assert swap_numbers(10,20)==(20,10)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10,20)==(20,10)\n    assert candidate(15,17)==(17,15)\n    assert candidate(100,200)==(200,100)\n",
       "language": "python"
     },
     {
       "id": 513,
-      "input": "Write a function to convert tuple into list by adding the given string after every element.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to convert tuple into list by adding the given string after every element.\nYour code should pass this test case: assert add_str((5, 6, 7, 4, 9) , \"FDF\") == [5, 'FDF', 6, 'FDF', 7, 'FDF', 4, 'FDF', 9, 'FDF']",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((5, 6, 7, 4, 9) , \"FDF\") == [5, 'FDF', 6, 'FDF', 7, 'FDF', 4, 'FDF', 9, 'FDF']\n    assert candidate((7, 8, 9, 10) , \"PF\") == [7, 'PF', 8, 'PF', 9, 'PF', 10, 'PF']\n    assert candidate((11, 14, 12, 1, 4) , \"JH\") == [11, 'JH', 14, 'JH', 12, 'JH', 1, 'JH', 4, 'JH']\n",
       "language": "python"
     },
     {
       "id": 879,
-      "input": "Write a function that matches a string that has an 'a' followed by anything, ending in 'b' by using regex.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function that matches a string that has an 'a' followed by anything, ending in 'b' by using regex.\nYour code should pass this test case: assert text_match(\"aabbbbd\") == 'Not matched!'",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"aabbbbd\") == 'Not matched!'\n    assert candidate(\"aabAbbbc\") == 'Not matched!'\n    assert candidate(\"accddbbjjjb\") == 'Found a match!'\n",
       "language": "python"
     },
     {
       "id": 963,
-      "input": "Write a function to calculate the discriminant value.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to calculate the discriminant value.\nYour code should pass this test case: assert discriminant_value(4,8,2)==(\"Two solutions\",32)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(4,8,2)==(\"Two solutions\",32)\n    assert candidate(5,7,9)==(\"no real solution\",-131)\n    assert candidate(0,0,9)==(\"one solution\",0)\n",
       "language": "python"
     },
     {
       "id": 778,
-      "input": "Write a function to pack consecutive duplicates of a given list elements into sublists.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to pack consecutive duplicates of a given list elements into sublists.\nYour code should pass this test case: assert pack_consecutive_duplicates([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4])==[[0, 0], [1], [2], [3], [4, 4], [5], [6, 6, 6], [7], [8], [9], [4, 4]]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([0, 0, 1, 2, 3, 4, 4, 5, 6, 6, 6, 7, 8, 9, 4, 4])==[[0, 0], [1], [2], [3], [4, 4], [5], [6, 6, 6], [7], [8], [9], [4, 4]]\n    assert candidate([10, 10, 15, 19, 18, 18, 17, 26, 26, 17, 18, 10])==[[10, 10], [15], [19], [18, 18], [17], [26, 26], [17], [18], [10]]\n    assert candidate(['a', 'a', 'b', 'c', 'd', 'd'])==[['a', 'a'], ['b'], ['c'], ['d', 'd']]\n",
       "language": "python"
     },
     {
       "id": 144,
-      "input": "Write a python function to find the sum of absolute differences in all pairs of the given array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the sum of absolute differences in all pairs of the given array.\nYour code should pass this test case: assert sum_Pairs([1,8,9,15,16],5) == 74",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,8,9,15,16],5) == 74\n    assert candidate([1,2,3,4],4) == 10\n    assert candidate([1,2,3,4,5,7,9,11,14],9) == 188\n",
       "language": "python"
     },
     {
       "id": 666,
-      "input": "Write a function to count occurrence of a character in a string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to count occurrence of a character in a string.\nYour code should pass this test case: assert count_char(\"Python\",'o')==1",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(\"Python\",'o')==1\n    assert candidate(\"little\",'t')==2\n    assert candidate(\"assert\",'s')==2\n",
       "language": "python"
     },
     {
       "id": 216,
-      "input": "Write a function to check if a nested list is a subset of another nested list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check if a nested list is a subset of another nested list.\nYour code should pass this test case: assert check_subset_list([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],[[12, 18, 23, 25, 45], [7, 11, 19, 24, 28], [1, 5, 8, 18, 15, 16]])==False",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],[[12, 18, 23, 25, 45], [7, 11, 19, 24, 28], [1, 5, 8, 18, 15, 16]])==False\n    assert candidate([[2, 3, 1], [4, 5], [6, 8]],[[4, 5], [6, 8]])==True\n    assert candidate([['a', 'b'], ['e'], ['c', 'd']],[['g']])==False\n",
       "language": "python"
     },
     {
       "id": 503,
-      "input": "Write a function to add consecutive numbers of a given list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to add consecutive numbers of a given list.\nYour code should pass this test case: assert add_consecutive_nums([1, 1, 3, 4, 4, 5, 6, 7])==[2, 4, 7, 8, 9, 11, 13]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 1, 3, 4, 4, 5, 6, 7])==[2, 4, 7, 8, 9, 11, 13]\n    assert candidate([4, 5, 8, 9, 6, 10])==[9, 13, 17, 15, 16]\n    assert candidate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])==[3, 5, 7, 9, 11, 13, 15, 17, 19]\n",
       "language": "python"
     },
     {
       "id": 274,
-      "input": "Write a python function to find sum of even index binomial coefficients.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find sum of even index binomial coefficients.\nYour code should pass this test case: assert even_binomial_Coeff_Sum(4) == 8",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(4) == 8\n    assert candidate(6) == 32\n    assert candidate(2) == 2\n",
       "language": "python"
     },
     {
       "id": 644,
-      "input": "Write a python function to reverse an array upto a given position.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to reverse an array upto a given position.\nYour code should pass this test case: assert reverse_Array_Upto_K([1, 2, 3, 4, 5, 6],4) == [4, 3, 2, 1, 5, 6]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1, 2, 3, 4, 5, 6],4) == [4, 3, 2, 1, 5, 6]\n    assert candidate([4, 5, 6, 7], 2) == [5, 4, 6, 7]\n    assert candidate([9, 8, 7, 6, 5],3) == [7, 8, 9, 6, 5]\n",
       "language": "python"
     },
     {
       "id": 277,
-      "input": "Write a function to filter a dictionary based on values.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to filter a dictionary based on values.\nYour code should pass this test case: assert dict_filter({'Cierra Vega': 175, 'Alden Cantrell': 180, 'Kierra Gentry': 165, 'Pierre Cox': 190},170)=={'Cierra Vega': 175, 'Alden Cantrell': 180, 'Pierre Cox': 190}",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate({'Cierra Vega': 175, 'Alden Cantrell': 180, 'Kierra Gentry': 165, 'Pierre Cox': 190},170)=={'Cierra Vega': 175, 'Alden Cantrell': 180, 'Pierre Cox': 190}\n    assert candidate({'Cierra Vega': 175, 'Alden Cantrell': 180, 'Kierra Gentry': 165, 'Pierre Cox': 190},180)=={ 'Alden Cantrell': 180, 'Pierre Cox': 190}\n    assert candidate({'Cierra Vega': 175, 'Alden Cantrell': 180, 'Kierra Gentry': 165, 'Pierre Cox': 190},190)=={ 'Pierre Cox': 190}\n",
       "language": "python"
     },
     {
       "id": 422,
-      "input": "Write a python function to find the average of cubes of first n natural numbers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the average of cubes of first n natural numbers.\nYour code should pass this test case: assert find_Average_Of_Cube(2) == 4.5",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(2) == 4.5\n    assert candidate(3) == 12\n    assert candidate(1) == 1\n",
       "language": "python"
     },
     {
       "id": 970,
-      "input": "Write a function to find minimum of two numbers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find minimum of two numbers.\nYour code should pass this test case: assert min_of_two(10,20)==10",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10,20)==10\n    assert candidate(19,15)==15\n    assert candidate(-10,-20)==-20\n",
       "language": "python"
     },
     {
       "id": 632,
-      "input": "Write a python function to move all zeroes to the end of the given list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to move all zeroes to the end of the given list.\nYour code should pass this test case: assert move_zero([1,0,2,0,3,4]) == [1,2,3,4,0,0]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,0,2,0,3,4]) == [1,2,3,4,0,0]\n    assert candidate([2,3,2,0,0,4,0,5,0]) == [2,3,2,4,5,0,0,0,0]\n    assert candidate([0,1,0,1,1]) == [1,1,1,0,0]\n",
       "language": "python"
     },
     {
       "id": 243,
-      "input": "Write a function to sort the given list based on the occurrence of first element of tuples.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to sort the given list based on the occurrence of first element of tuples.\nYour code should pass this test case: assert sort_on_occurence([(1, 'Jake'), (2, 'Bob'), (1, 'Cara')]) == [(1, 'Jake', 'Cara', 2), (2, 'Bob', 1)]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([(1, 'Jake'), (2, 'Bob'), (1, 'Cara')]) == [(1, 'Jake', 'Cara', 2), (2, 'Bob', 1)]\n    assert candidate([('b', 'ball'), ('a', 'arm'), ('b', 'b'), ('a', 'ant')]) == [('b', 'ball', 'b', 2), ('a', 'arm', 'ant', 2)]\n    assert candidate([(2, 'Mark'), (3, 'Maze'), (2, 'Sara')]) == [(2, 'Mark', 'Sara', 2), (3, 'Maze', 1)]\n",
       "language": "python"
     },
     {
       "id": 227,
-      "input": "Write a function to find minimum of three numbers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find minimum of three numbers.\nYour code should pass this test case: assert min_of_three(10,20,0)==0",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10,20,0)==0\n    assert candidate(19,15,18)==15\n    assert candidate(-10,-20,-30)==-30\n",
       "language": "python"
     },
     {
       "id": 213,
-      "input": "Write a function to perform the concatenation of two string tuples.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to perform the concatenation of two string tuples.\nYour code should pass this test case: assert concatenate_strings((\"Manjeet\", \"Nikhil\", \"Akshat\"), (\" Singh\", \" Meherwal\", \" Garg\")) == ('Manjeet Singh', 'Nikhil Meherwal', 'Akshat Garg')",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((\"Manjeet\", \"Nikhil\", \"Akshat\"), (\" Singh\", \" Meherwal\", \" Garg\")) == ('Manjeet Singh', 'Nikhil Meherwal', 'Akshat Garg')\n    assert candidate((\"Shaik\", \"Ayesha\", \"Sanya\"), (\" Dawood\", \" Begum\", \" Singh\")) == ('Shaik Dawood', 'Ayesha Begum', 'Sanya Singh')\n    assert candidate((\"Harpreet\", \"Priyanka\", \"Muskan\"), (\"Kour\", \" Agarwal\", \"Sethi\")) == ('HarpreetKour', 'Priyanka Agarwal', 'MuskanSethi')\n",
       "language": "python"
     },
     {
       "id": 645,
-      "input": "Write a function to find the product of it\u2019s kth index in the given tuples.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the product of it\u2019s kth index in the given tuples.\nYour code should pass this test case: assert find_k_product([(5, 6, 7), (1, 3, 5), (8, 9, 19)], 2) == 665",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([(5, 6, 7), (1, 3, 5), (8, 9, 19)], 2) == 665\n    assert candidate([(6, 7, 8), (2, 4, 6), (9, 10, 20)], 1) == 280\n    assert candidate([(7, 8, 9), (3, 5, 7), (10, 11, 21)], 0) == 210\n",
       "language": "python"
     },
     {
       "id": 244,
-      "input": "Write a python function to find the next perfect square greater than a given number.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the next perfect square greater than a given number.\nYour code should pass this test case: assert next_Perfect_Square(35) == 36",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(35) == 36\n    assert candidate(6) == 9\n    assert candidate(9) == 16\n",
       "language": "python"
     },
     {
       "id": 773,
-      "input": "Write a function to find the occurrence and position of the substrings within a string.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the occurrence and position of the substrings within a string.\nYour code should pass this test case: assert occurance_substring('python programming, python language','python')==('python', 0, 6)",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate('python programming, python language','python')==('python', 0, 6)\n    assert candidate('python programming,programming language','programming')==('programming', 7, 18)\n    assert candidate('python programming,programming language','language')==('language', 31, 39)\n",
       "language": "python"
     },
     {
       "id": 962,
-      "input": "Write a python function to find the sum of all even natural numbers within the range l and r.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to find the sum of all even natural numbers within the range l and r.\nYour code should pass this test case: assert sum_Even(2,5) == 6",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(2,5) == 6\n    assert candidate(3,8) == 18\n    assert candidate(4,6) == 10\n",
       "language": "python"
     },
     {
       "id": 514,
-      "input": "Write a function to find the summation of tuple elements in the given tuple list.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the summation of tuple elements in the given tuple list.\nYour code should pass this test case: assert sum_elements((7, 8, 9, 1, 10, 7)) == 42",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate((7, 8, 9, 1, 10, 7)) == 42\n    assert candidate((1, 2, 3, 4, 5, 6)) == 21\n    assert candidate((11, 12 ,13 ,45, 14)) == 95\n",
       "language": "python"
     },
     {
       "id": 296,
-      "input": "Write a python function to count inversions in an array.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count inversions in an array.\nYour code should pass this test case: assert get_Inv_Count([1,20,6,4,5],5) == 5",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,20,6,4,5],5) == 5\n    assert candidate([1,2,1],3) == 1\n    assert candidate([1,2,5,6,1],5) == 3\n",
       "language": "python"
     },
     {
       "id": 393,
-      "input": "Write a function to find the list with maximum length using lambda function.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find the list with maximum length using lambda function.\nYour code should pass this test case: assert max_length_list([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]])==(3, [13, 15, 17])",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([[0], [1, 3], [5, 7], [9, 11], [13, 15, 17]])==(3, [13, 15, 17])\n    assert candidate([[1,2,3,4,5],[1,2,3,4],[1,2,3],[1,2],[1]])==(5,[1,2,3,4,5])\n    assert candidate([[3,4,5],[6,7,8,9],[10,11,12]])==(4,[6,7,8,9])\n",
       "language": "python"
     },
     {
       "id": 896,
-      "input": "Write a function to sort a list in increasing order by the last element in each tuple from a given list of non-empty tuples.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to sort a list in increasing order by the last element in each tuple from a given list of non-empty tuples.\nYour code should pass this test case: assert sort_list_last([(2, 5), (1, 2), (4, 4), (2, 3), (2, 1)])==[(2, 1), (1, 2), (2, 3), (4, 4), (2, 5)] ",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([(2, 5), (1, 2), (4, 4), (2, 3), (2, 1)])==[(2, 1), (1, 2), (2, 3), (4, 4), (2, 5)] \n    assert candidate([(9,8), (4, 7), (3,5), (7,9), (1,2)])==[(1,2), (3,5), (4,7), (9,8), (7,9)] \n    assert candidate([(20,50), (10,20), (40,40)])==[(10,20),(40,40),(20,50)] \n",
       "language": "python"
     },
     {
       "id": 955,
-      "input": "Write a function to find out, if the given number is abundant.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to find out, if the given number is abundant.\nYour code should pass this test case: assert is_abundant(12)==True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(12)==True\n    assert candidate(13)==False\n    assert candidate(9)==False\n",
       "language": "python"
     },
     {
       "id": 927,
-      "input": "Write a function to calculate the height of the given binary tree.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to calculate the height of the given binary tree.\nYour code should pass this test case: assert (max_height(root)) == 3",
       "test": "",
       "language": "python"
     },
     {
       "id": 281,
-      "input": "Write a python function to check if the elements of a given list are unique or not.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to check if the elements of a given list are unique or not.\nYour code should pass this test case: assert all_unique([1,2,3]) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([1,2,3]) == True\n    assert candidate([1,2,1,2]) == False\n    assert candidate([1,2,3,4,5]) == True\n",
       "language": "python"
     },
     {
       "id": 801,
-      "input": "Write a python function to count the number of equal numbers from three given integers.",
+      "input": "You are an expert Python programmer, and here is your task: Write a python function to count the number of equal numbers from three given integers.\nYour code should pass this test case: assert test_three_equal(1,1,1) == 3",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(1,1,1) == 3\n    assert candidate(-1,-2,-3) == 0\n    assert candidate(1,2,2) == 2\n",
       "language": "python"
     },
     {
       "id": 127,
-      "input": "Write a function to multiply two integers without using the * operator in python.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to multiply two integers without using the * operator in python.\nYour code should pass this test case: assert multiply_int(10,20)==200",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate(10,20)==200\n    assert candidate(5,10)==50\n    assert candidate(4,8)==32\n",
       "language": "python"
     },
     {
       "id": 26,
-      "input": "Write a function to check if the given tuple list has all k elements.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to check if the given tuple list has all k elements.\nYour code should pass this test case: assert check_k_elements([(4, 4), (4, 4, 4), (4, 4), (4, 4, 4, 4), (4, )], 4) == True",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([(4, 4), (4, 4, 4), (4, 4), (4, 4, 4, 4), (4, )], 4) == True\n    assert candidate([(7, 7, 7), (7, 7)], 7) == True\n    assert candidate([(9, 9), (9, 9, 9, 9)], 7) == False\n    assert candidate([(4, 4), (4, 4, 4), (4, 4), (4, 4, 6, 4), (4, )], 4) == False\n",
       "language": "python"
     },
     {
       "id": 749,
-      "input": "Write a function to sort a given list of strings of numbers numerically.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to sort a given list of strings of numbers numerically.\nYour code should pass this test case: assert sort_numeric_strings( ['4','12','45','7','0','100','200','-12','-500'])==[-500, -12, 0, 4, 7, 12, 45, 100, 200]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate( ['4','12','45','7','0','100','200','-12','-500'])==[-500, -12, 0, 4, 7, 12, 45, 100, 200]\n    assert candidate(['2','3','8','4','7','9','8','2','6','5','1','6','1','2','3','4','6','9','1','2'])==[1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 5, 6, 6, 6, 7, 8, 8, 9, 9]\n    assert candidate(['1','3','5','7','1', '3','13', '15', '17','5', '7 ','9','1', '11'])==[1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 11, 13, 15, 17]\n",
       "language": "python"
     },
     {
       "id": 839,
-      "input": "Write a function to sort the tuples alphabetically by the first item of each tuple.",
+      "input": "You are an expert Python programmer, and here is your task: Write a function to sort the tuples alphabetically by the first item of each tuple.\nYour code should pass this test case: assert sort_tuple([(\"Amana\", 28), (\"Zenat\", 30), (\"Abhishek\", 29),(\"Nikhil\", 21), (\"B\", \"C\")]) == [('Abhishek', 29), ('Amana', 28), ('B', 'C'), ('Nikhil', 21), ('Zenat', 30)]",
       "test": "\n\nMETADATA = {\n    'author': 'mbpp',\n    'dataset': 'test'\n}\n\n\ndef check(candidate):\n    assert candidate([(\"Amana\", 28), (\"Zenat\", 30), (\"Abhishek\", 29),(\"Nikhil\", 21), (\"B\", \"C\")]) == [('Abhishek', 29), ('Amana', 28), ('B', 'C'), ('Nikhil', 21), ('Zenat', 30)]\n    assert candidate([(\"aaaa\", 28), (\"aa\", 30), (\"bab\", 29), (\"bb\", 21), (\"csa\", \"C\")]) == [('aa', 30), ('aaaa', 28), ('bab', 29), ('bb', 21), ('csa', 'C')]\n    assert candidate([(\"Sarala\", 28), (\"Ayesha\", 30), (\"Suman\", 29),(\"Sai\", 21), (\"G\", \"H\")]) == [('Ayesha', 30), ('G', 'H'), ('Sai', 21), ('Sarala', 28), ('Suman', 29)]\n",
       "language": "python"
     }


### PR DESCRIPTION
In MBPP dataset, the text instruction is too ambiguous, e.g. ```Write a function to extract the even elements in the nested mixed tuple.```, which can make the model confused about the function name and input/output format. 

To fix that, I added the first test case in the input, to help the model understand the function format. 