### PR TITLE
Unify ratio as a hyperparameter across all methods

### DIFF
--- a/model_collaboration/method/api_cascade.py
+++ b/model_collaboration/method/api_cascade.py
@@ -42,6 +42,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     mode = hyperparameters.get("mode", "logit") # confidence: `logit` or `just_ask`
     assert mode == "logit" or mode == "just_ask", "unsupported mode"
     percentage = hyperparameters.get("percentage", 0.5) # threshold percentage, default Top 50%
+    ratio = hyperparameters.get("ratio", 1.0)
 
     print(f"Current mode: {mode}")
 
@@ -49,7 +50,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     if mode == "logit":
         threshold_list = []
         print(f"Finding threshold in dev set under logit mode")
-        dev_input_list = eval.prepare_inputs(task, task_type, "dev")
+        dev_input_list = eval.prepare_inputs(task, task_type, "dev", ratio=ratio)
         for i in range(len(model_names)-1): # find threshld for every model except last model
             output_list, list_logit_scores_list = distributed_generation.batch_generate_text_with_score(
                         model_name=model_names[0],
@@ -71,7 +72,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
             threshold_list.append(threshold)
 
     # prepare test set input
-    test_input_list = eval.prepare_inputs(task, task_type, "test")
+    test_input_list = eval.prepare_inputs(task, task_type, "test", ratio=ratio)
     # record each problem deferral state
     unsolved_dict = {i: True for i in range(len(test_input_list))}
     answer_dict = {i: "" for i in range(len(test_input_list))}
@@ -165,7 +166,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     assert len(test_input_list) == len(final_output_list), "length of test_input_list and final_output_list is not same"
 
     # evaluate the final outputs
-    test_scores = eval.get_scores(task, task_type, "test", final_output_list)
+    test_scores = eval.get_scores(task, task_type, "test", final_output_list, ratio=ratio)
     avg_test_score = sum(test_scores) / len(test_scores)
     print("Final test {} score of the approach: {}".format(task, avg_test_score))
 

--- a/model_collaboration/method/api_collm.py
+++ b/model_collaboration/method/api_collm.py
@@ -737,6 +737,7 @@ def run_inference(
     threshold_warmup_schedule="none",
     threshold_warmup_steps=15,
     save_results=True,
+    ratio=1.0,
 ):
     """
     Run inference with trained Co-LLM models.
@@ -785,7 +786,7 @@ def run_inference(
 
     # Prepare inputs using eval.prepare_inputs
     logger.info("Preparing inputs...")
-    test_input_list = eval.prepare_inputs(task, task_type, split)
+    test_input_list = eval.prepare_inputs(task, task_type, split, ratio=ratio)
     logger.info(f"Loaded {len(test_input_list)} inputs")
 
     # Initialize inference
@@ -808,7 +809,7 @@ def run_inference(
 
     # Evaluate
     logger.info("Evaluating outputs...")
-    test_scores = eval.get_scores(task, task_type, split, outputs)
+    test_scores = eval.get_scores(task, task_type, split, outputs, ratio=ratio)
     avg_test_score = sum(test_scores) / len(test_scores) if test_scores else 0.0
 
     logger.info("=" * 80)
@@ -1077,6 +1078,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     max_tokens = hyperparameters.get("max_response_length", 512)
     threshold_warmup_schedule = hyperparameters.get("threshold_warmup_schedule", "none")
     threshold_warmup_steps = hyperparameters.get("threshold_warmup_steps", 15)
+    ratio = hyperparameters.get("ratio", 1.0)
 
     avg_score = run_inference(
         task=task,
@@ -1090,6 +1092,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
         max_tokens=max_tokens,
         threshold_warmup_schedule=threshold_warmup_schedule,
         threshold_warmup_steps=threshold_warmup_steps,
+        ratio=ratio,
     )
 
     logger.info(f"\nFinal test score: {avg_score:.4f}")

--- a/model_collaboration/method/api_graph_routing.py
+++ b/model_collaboration/method/api_graph_routing.py
@@ -45,6 +45,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     scenario = hyperparameters.get("scenario", "Performance First")  # "Performance First", "Balance", "Cost First"
     model_descriptions = hyperparameters.get("model_descriptions", None)
     task_description = hyperparameters.get("task_description", task) # default to be task name
+    ratio = hyperparameters.get("ratio", 1.0)
     
     assert model_descriptions != None, "The model_descriptions is needed in hyperparameters in task config."
     assert task_description != None, "The task_description is needed in hyperparameters in task config."
@@ -52,7 +53,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
 
     # Preparing router training data from dev set and get scores
     print("Preparing dev set data...")
-    dev_input_list = eval.prepare_inputs(task, task_type, "dev")
+    dev_input_list = eval.prepare_inputs(task, task_type, "dev", ratio=ratio)
     list_of_input_list = [dev_input_list for _ in model_names]
     list_of_output_list = distributed_generation.distributed_generation(
         model_names,
@@ -63,7 +64,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     list_of_dev_scores = []
     for i in range(len(model_names)):
         dev_outputs = list_of_output_list[i]
-        dev_score = eval.get_scores(task, task_type, "dev", dev_outputs)
+        dev_score = eval.get_scores(task, task_type, "dev", dev_outputs, ratio=ratio)
         avg_dev_score = sum(dev_score) / len(dev_score)
         list_of_dev_scores.append(dev_score)
         print("Model: {}, dev {} score: {}".format(model_names[i], task_type, avg_dev_score))
@@ -239,7 +240,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     
     # Using the router for the test set
     print("Routing test set queries...")
-    test_input_list = eval.prepare_inputs(task, task_type, "test")
+    test_input_list = eval.prepare_inputs(task, task_type, "test", ratio=ratio)
     
     # Extract embeddings for test queries
     test_query_embeddings = get_embedding(embedding_model_name, test_input_list)
@@ -328,7 +329,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
         list_of_output_list[model_idx].pop(0)
     
     # Evaluate
-    test_scores = eval.get_scores(task, task_type, "test", final_outputs)
+    test_scores = eval.get_scores(task, task_type, "test", final_outputs, ratio=ratio)
     avg_test_score = sum(test_scores) / len(test_scores)
     print("Final test {} score after graph router: {}".format(task, avg_test_score))
     

--- a/model_collaboration/method/api_mentor_collab.py
+++ b/model_collaboration/method/api_mentor_collab.py
@@ -37,6 +37,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     mlp_task = hyperparameters.get("task", "General")  # Task type for MLP model (Math or General)
     mode = hyperparameters.get("mode", "free")
     mlp_threshold = hyperparameters.get("mlp_threshold", 0.5)
+    ratio = hyperparameters.get("ratio", 1.0)
 
     if mode == "train":
         if generator not in MENTOR_COLLAB_TRAIN_SUPPORT_MODELS:
@@ -55,13 +56,13 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
         task=mlp_task,
         mlp_threshold=mlp_threshold
     )
-    test_input_list = eval.prepare_inputs(task, task_type, "test")
+    test_input_list = eval.prepare_inputs(task, task_type, "test", ratio=ratio)
     outputs = []
     for input in tqdm(test_input_list, desc="Generating outputs"):
         output = mentor_collab.generate(input, max_new_tokens)
         outputs.append(output)
     
-    test_scores = eval.get_scores(task, task_type, "test", outputs)
+    test_scores = eval.get_scores(task, task_type, "test", outputs, ratio=ratio)
     avg_test_scores = sum(test_scores) / len(test_scores)
     print("Final test {} score after mentorcollab: {}".format(task, avg_test_scores))
     

--- a/model_collaboration/method/api_nudging.py
+++ b/model_collaboration/method/api_nudging.py
@@ -590,7 +590,8 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     search_nudging = hyperparameters.get("search_nudging", False)
     search_gamma = hyperparameters.get("search_gamma", False)
     use_kv_cache = hyperparameters.get("use_kv_cache", False)
-    
+    ratio = hyperparameters.get("ratio", 1.0)
+
     if use_kv_cache:
         print("Using KV cache..., outputs can be different from the one without KV cache")
     else:
@@ -601,8 +602,8 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
         model_devices=["cuda:{}".format(gpu_id) for gpu_id in gpu_ids],
     )
     
-    dev_input_list = eval.prepare_inputs(task, task_type, "dev")
-    
+    dev_input_list = eval.prepare_inputs(task, task_type, "dev", ratio=ratio)
+
     gamma_list = [gamma]
     nudging_model_id_list = [nudging_model_id]
 
@@ -637,7 +638,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
                 nudging_model_id=nudging_model_id,
                 use_kv_cache=use_kv_cache,
             )
-            dev_score = eval.get_scores(task, task_type, "dev", outputs)
+            dev_score = eval.get_scores(task, task_type, "dev", outputs, ratio=ratio)
             avg_dev_score = sum(dev_score) / len(dev_score)
             if avg_dev_score > best_dev_score:
                 best_gamma = gamma
@@ -648,7 +649,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     else:
         print("No search, using default gamma: {}, base model: {}, nudging model: {}".format(best_gamma, model_names[base_model_id], model_names[best_nudging_model_id]))
 
-    test_input_list = eval.prepare_inputs(task, task_type, "test")
+    test_input_list = eval.prepare_inputs(task, task_type, "test", ratio=ratio)
     outputs = nudging_object.batch_generate(
         prompts=test_input_list,
         batch_size=batch_size,
@@ -661,7 +662,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
         use_kv_cache=use_kv_cache,
     )
 
-    test_scores = eval.get_scores(task, task_type, "test", outputs)
+    test_scores = eval.get_scores(task, task_type, "test", outputs, ratio=ratio)
     avg_test_scores = sum(test_scores) / len(test_scores)
     print("Final test {} score after nudging: {}".format(task, avg_test_scores))
 

--- a/model_collaboration/method/api_prompt_routing.py
+++ b/model_collaboration/method/api_prompt_routing.py
@@ -15,9 +15,10 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     if model_descriptions is None:
         raise ValueError("model_descriptions must be provided in hyperparameters")
     assert len(model_descriptions) == len(model_names), "Length of model_descriptions must match length of model_names"
+    ratio = hyperparameters.get("ratio", 1.0)
 
     # selecting a model as the prompt-based router based on performance on the dev set
-    dev_input_list = eval.prepare_inputs(task, task_type, "dev")
+    dev_input_list = eval.prepare_inputs(task, task_type, "dev", ratio=ratio)
     list_of_input_list = [dev_input_list for _ in model_names]
 
     list_of_output_list = distributed_generation.distributed_generation(
@@ -29,7 +30,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     list_of_dev_scores = []
     for i in range(len(model_names)):
         dev_outputs = list_of_output_list[i]
-        dev_score = eval.get_scores(task, task_type, "dev", dev_outputs)
+        dev_score = eval.get_scores(task, task_type, "dev", dev_outputs, ratio=ratio)
         avg_dev_score = sum(dev_score) / len(dev_score)
         list_of_dev_scores.append(avg_dev_score)
         print("Model: {}, dev {} score: {}".format(model_names[i], task_type, avg_dev_score))
@@ -39,7 +40,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     print("Best model selected for prompt-based routing: {}".format(best_model_name))
 
     # prompt-based routing: the best model routes each test input to the most suitable model based on model descriptions
-    test_input_list = eval.prepare_inputs(task, task_type, "test")
+    test_input_list = eval.prepare_inputs(task, task_type, "test", ratio=ratio)
     routing_prompts = []
     for test_input in test_input_list:
         prompt = "You are an AI assistant that routes user questions to the most suitable AI model based on their descriptions.\n\n"
@@ -84,7 +85,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
         response = list_of_output_list[model_index].pop(0)
         final_responses.append(response)
     
-    test_scores = eval.get_scores(task, task_type, "test", final_responses)
+    test_scores = eval.get_scores(task, task_type, "test", final_responses, ratio=ratio)
     avg_test_score = sum(test_scores) / len(test_scores)
     print("Final test {} score prompt-based routing: {}".format(task, avg_test_score))
 

--- a/model_collaboration/method/api_switch_generation.py
+++ b/model_collaboration/method/api_switch_generation.py
@@ -122,7 +122,7 @@ def reward_model_scores(gpu_id, list_of_input, list_of_output):
         scores.append(score)
     return scores
 
-def get_all_inputs(task=None):
+def get_all_inputs(task=None, ratio=1.0):
     list_of_all_inputs = []
     files = os.listdir("model_collaboration/data/")
     for file in files:
@@ -130,7 +130,7 @@ def get_all_inputs(task=None):
             if file == task + ".json":
                 with open(os.path.join("model_collaboration/data/", file), "r") as f:
                     task_type = json.load(f)["task_type"]
-                inputs = eval.prepare_inputs(file[:-5], task_type, "dev")
+                inputs = eval.prepare_inputs(file[:-5], task_type, "dev", ratio=ratio)
                 list_of_all_inputs.extend(inputs)
         except:
             print("Error processing file: {}".format(file))
@@ -157,11 +157,12 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     reward_model_gpu_id = hyperparameters.get("reward_model_gpu_id", gpu_ids[0])
     reward_model_name = hyperparameters.get("reward_model_name", "Skywork/Skywork-Reward-Llama-3.1-8B-v0.2")
     wait_flag = hyperparameters.get("wait_flag", False)
+    ratio = hyperparameters.get("ratio", 1.0)
 
     if selector_model_name is None:
         # train a selector model
         print("Training selector model...")
-        input_list = get_all_inputs(task)
+        input_list = get_all_inputs(task, ratio=ratio)
         sft_data_points = []
 
         for iter in range(training_instance_num // batch_size):
@@ -293,7 +294,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
         selector_model_name = "model_collaboration/logs/selector_sft_{}".format(task)
     else:
         print("Using pre-defined selector model: {}".format(selector_model_name))
-    test_inputs = eval.prepare_inputs(task, task_type, "test")
+    test_inputs = eval.prepare_inputs(task, task_type, "test", ratio=ratio)
     final_outputs, generation_logs = switch_generation(
         test_inputs,
         model_names,
@@ -306,7 +307,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
         wait_flag=wait_flag
     )
 
-    test_scores = eval.get_scores(task, task_type, "test", final_outputs)
+    test_scores = eval.get_scores(task, task_type, "test", final_outputs, ratio=ratio)
     avg_test_score = sum(test_scores) / len(test_scores)
     print("Final test {} score switch generation: {}".format(task, avg_test_score))
 

--- a/model_collaboration/method/api_trained_router.py
+++ b/model_collaboration/method/api_trained_router.py
@@ -46,9 +46,10 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     model_descriptions = hyperparameters.get("model_descriptions", None)
     reward_model_gpu_id = hyperparameters.get("reward_model_gpu_id", gpu_ids[0])
     reward_model_name = hyperparameters.get("reward_model_name", "Skywork/Skywork-Reward-Llama-3.1-8B-v0.2")
+    ratio = hyperparameters.get("ratio", 1.0)
 
     # preparing router SFT data
-    dev_input_list = eval.prepare_inputs(task, task_type, "dev")
+    dev_input_list = eval.prepare_inputs(task, task_type, "dev", ratio=ratio)
     list_of_input_list = [dev_input_list for _ in model_names]
 
     list_of_output_list = distributed_generation.distributed_generation(
@@ -60,7 +61,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     list_of_dev_scores = [] # len(model_names) * len(dev_input_list)
     for i in range(len(model_names)):
         dev_outputs = list_of_output_list[i]
-        dev_score = eval.get_scores(task, task_type, "dev", dev_outputs)
+        dev_score = eval.get_scores(task, task_type, "dev", dev_outputs, ratio=ratio)
         list_of_dev_scores.append(dev_score)
 
     # reward modeling scoring, in case there is a tie on the task metric
@@ -174,7 +175,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     router_model_name = "model_collaboration/logs/router_sft_{}".format(task)
 
     # using the router for the test set
-    test_input_list = eval.prepare_inputs(task, task_type, "test")
+    test_input_list = eval.prepare_inputs(task, task_type, "test", ratio=ratio)
     selected_model_indices = []
 
     router_prompts = []
@@ -232,7 +233,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
         # pop the used output
         list_of_output_list[selected_model_indices[j]].pop(0)
 
-    test_scores = eval.get_scores(task, task_type, "test", final_outputs)
+    test_scores = eval.get_scores(task, task_type, "test", final_outputs, ratio=ratio)
     avg_test_score = sum(test_scores) / len(test_scores)
     print("Final test {} score after trained router: {}".format(task, avg_test_score))
 

--- a/model_collaboration/method/logit_logit_contrastive.py
+++ b/model_collaboration/method/logit_logit_contrastive.py
@@ -32,9 +32,10 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     # method-specific hyperparameters
     k = hyperparameters.get("k", 1) # top-k and bottom-k
     lambda_ = hyperparameters.get("lambda_", 0.2) # scaler for summed logit contrastion
+    ratio = hyperparameters.get("ratio", 1.0)
 
     # evaluate models on the dev set to know the top-k and bottom-k models
-    dev_input_list = eval.prepare_inputs(task, task_type, "dev")
+    dev_input_list = eval.prepare_inputs(task, task_type, "dev", ratio=ratio)
     list_of_input_list = [dev_input_list for _ in model_names]
 
     list_of_output_list = distributed_generation.distributed_generation(
@@ -46,7 +47,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     list_of_dev_scores = []
     for i in range(len(model_names)):
         dev_outputs = list_of_output_list[i]
-        dev_score = eval.get_scores(task, task_type, "dev", dev_outputs)
+        dev_score = eval.get_scores(task, task_type, "dev", dev_outputs, ratio=ratio)
         avg_dev_score = sum(dev_score) / len(dev_score)
         list_of_dev_scores.append(avg_dev_score)
         print("Model: {}, dev {} score: {}".format(model_names[i], task, avg_dev_score))
@@ -66,7 +67,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
         tokenizer=tokenizer
     )
 
-    test_input_list = eval.prepare_inputs(task, task_type, "test")
+    test_input_list = eval.prepare_inputs(task, task_type, "test", ratio=ratio)
     outputs = logit_calc_object.batch_generate(
         prompts=test_input_list,
         tokenizer=logit_calc_object.tokenizer,
@@ -77,7 +78,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
         arithmetic_func=logit_operation_generator(k, lambda_)
     )
 
-    test_scores = eval.get_scores(task, task_type, "test", outputs)
+    test_scores = eval.get_scores(task, task_type, "test", outputs, ratio=ratio)
     avg_test_scores = sum(test_scores) / len(test_scores)
     print("Final test {} score after logit contrastive: {}".format(task, avg_test_scores))
 

--- a/model_collaboration/method/logit_logit_fusion.py
+++ b/model_collaboration/method/logit_logit_fusion.py
@@ -18,6 +18,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
 
     # method-specific hyperparameters
     mode = hyperparameters.get("mode", "average") # average or optimized
+    ratio = hyperparameters.get("ratio", 1.0)
 
     if mode == "optimized":
         raise NotImplementedError("Optimized logit fusion is not implemented yet.")
@@ -31,7 +32,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     )
 
     # preparing inputs
-    test_input_list = eval.prepare_inputs(task, task_type, "test")
+    test_input_list = eval.prepare_inputs(task, task_type, "test", ratio=ratio)
     outputs = logit_calc_object.batch_generate(
         prompts=test_input_list,
         tokenizer=logit_calc_object.tokenizer,
@@ -41,7 +42,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
         temprature=temperature
     )
 
-    test_scores = eval.get_scores(task, task_type, "test", outputs)
+    test_scores = eval.get_scores(task, task_type, "test", outputs, ratio=ratio)
     avg_test_scores = sum(test_scores) / len(test_scores)
     print("Final test {} score after logit fusion: {}".format(task, avg_test_scores))
 

--- a/model_collaboration/method/sample_approach.py
+++ b/model_collaboration/method/sample_approach.py
@@ -27,6 +27,8 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     script_dir = script_path.parent.parent.parent
     os.chdir(script_dir)
 
+    ratio = hyperparameters.get("ratio", 1.0)
+
     # 1. optionally, extract the general hyperparameters from the hyperparameters dict
     # these four are included in any config file by default
     # this is useful if you are handling generation/finetuning without the (amazing) helper functions provided
@@ -55,7 +57,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     # if you ever saves anything during this step, make sure to save it in `model_collaboration/logs/<your_method_name>/`!
 
     # a most simple example, select the best model based on dev set performance
-    dev_input_list = eval.prepare_inputs(task, task_type, "dev") # grab the inputs for the dev set
+    dev_input_list = eval.prepare_inputs(task, task_type, "dev", ratio=ratio) # grab the inputs for the dev set
 
     # evaluate every model on it through distributed generation
     list_of_input_list = [dev_input_list for _ in model_names] # replicate the dev inputs for each model
@@ -68,7 +70,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     list_of_dev_scores = []
     for i in range(len(model_names)):
         dev_outputs = list_of_output_list[i]
-        dev_score = eval.get_scores(task, task_type, "dev", dev_outputs) # send the outputs to the eval module to get a list of per-input scores
+        dev_score = eval.get_scores(task, task_type, "dev", dev_outputs, ratio=ratio) # send the outputs to the eval module to get a list of per-input scores
         avg_dev_score = sum(dev_score) / len(dev_score)
         list_of_dev_scores.append(avg_dev_score)
         print("Model: {}, dev {} score: {}".format(model_names[i], task, avg_dev_score))
@@ -82,7 +84,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     # based on the stuff you did in the dev set, you arrived at some final approach
     # generate responses with it, evaluate it, do logging
 
-    test_input_list = eval.prepare_inputs(task, task_type, "test") # grab the inputs for the test set
+    test_input_list = eval.prepare_inputs(task, task_type, "test", ratio=ratio) # grab the inputs for the test set
 
     # let's implement a multi-agent summary approach
     # each model generates their own response
@@ -115,7 +117,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     )[0] # get the only output list, [0] is important because the output is list of list and [0] takes the list out
 
     # evaluate the final outputs
-    test_scores = eval.get_scores(task, task_type, "test", final_output_list)
+    test_scores = eval.get_scores(task, task_type, "test", final_output_list, ratio=ratio)
     avg_test_score = sum(test_scores) / len(test_scores)
     print("Final test {} score of the approach: {}".format(task, avg_test_score))
 

--- a/model_collaboration/method/single_model.py
+++ b/model_collaboration/method/single_model.py
@@ -92,6 +92,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     top_p = hyperparameters.get("top_p", 0.9)
     batch_size = hyperparameters.get("batch_size", 8)
     load_in_8bit = hyperparameters.get("load_in_8bit", False)
+    ratio = hyperparameters.get("ratio", 1.0)
 
     assert len(model_names) == 1, "This method only supports a single model."
 
@@ -106,7 +107,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     resume = hyperparameters.get("resume", False) or model_name in RESUME_MODELS
 
     # evaluate on the test set
-    test_input_list = eval.prepare_inputs(task, task_type, "test")
+    test_input_list = eval.prepare_inputs(task, task_type, "test", ratio=ratio)
 
     # Pre-fill output list from checkpoint (mid-run save) or existing result log
     output_list = [None] * len(test_input_list)
@@ -180,7 +181,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
             if resume:
                 save_checkpoint(task, simple_model_name, test_input_list, output_list)
 
-    test_scores = eval.get_scores(task, task_type, "test", output_list)
+    test_scores = eval.get_scores(task, task_type, "test", output_list, ratio=ratio)
     avg_test_score = sum(test_scores) / len(test_scores)
     print("Model: {}, test {} score: {}".format(model_names[0], task, avg_test_score))
 

--- a/model_collaboration/method/text_agglm.py
+++ b/model_collaboration/method/text_agglm.py
@@ -61,6 +61,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     temperature = hyperparameters.get("temperature", 1.0)
     batch_size = hyperparameters.get("train_batch_size", 4)
     s = hyperparameters.get("sample_size", 2)
+    ratio = hyperparameters.get("ratio", 1.0)
     m = len(model_names)
 
     # prepare training data
@@ -70,7 +71,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
         if os.path.exists(agglm_log_path + '/' + file_name):
             dev_res_list = json.load(open(agglm_log_path + '/' + file_name, 'r'))
         else:
-            dev_input_list, dev_id_list = eval.prepare_inputs(task, task_type, 'dev', return_id=True)
+            dev_input_list, dev_id_list = eval.prepare_inputs(task, task_type, 'dev', ratio=ratio, return_id=True)
             dev_res_list = [{'id': _id, 'input': _input, 'generation': []} for _input, _id in zip(dev_input_list, dev_id_list)]
             dev_output_list = distributed_generation.distributed_generation(
                 model_names,
@@ -83,7 +84,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
 
         for i in range(s * m):
             judge_list = [data['generation'][i] for data in dev_res_list]
-            score_list, parsed_output_list = eval.get_scores(task, task_type, "dev", judge_list, return_output=True)
+            score_list, parsed_output_list = eval.get_scores(task, task_type, "dev", judge_list, ratio=ratio, return_output=True)
             for data, parsed_output, score in zip(dev_res_list, parsed_output_list, score_list):
                 if i == 0:
                     data['parsed_generation'] = [parsed_output]
@@ -168,7 +169,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
 
         def reward_func(prompts, completions, **kwargs):
             responses = [completion[0]['content'] for completion in completions]
-            return eval.get_scores(task, task_type, "dev", responses, id_list=kwargs['id'])
+            return eval.get_scores(task, task_type, "dev", responses, ratio=ratio, id_list=kwargs['id'])
 
         trainer = GRPOTrainer(
             model=agg_model,
@@ -191,7 +192,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
             dist.destroy_process_group()
 
     new_gpu_ids = [i for i in range(len(gpu_ids))]
-    test_input_list = eval.prepare_inputs(task, task_type, 'test')
+    test_input_list = eval.prepare_inputs(task, task_type, 'test', ratio=ratio)
     list_of_test_output_list = distributed_generation.distributed_generation(
         model_names,
         [test_input_list for _ in model_names],
@@ -206,7 +207,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
         [agg_input_list],
         [new_gpu_ids[0]]
     )
-    test_scores = eval.get_scores(task, task_type, "test", agg_output_list[0])
+    test_scores = eval.get_scores(task, task_type, "test", agg_output_list[0], ratio=ratio)
 
     avg_test_score = sum(test_scores) / len(test_scores)
     print("Agglm test {} score: {}".format(task, avg_test_score))

--- a/model_collaboration/method/text_bbmas.py
+++ b/model_collaboration/method/text_bbmas.py
@@ -702,6 +702,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     agent_idle_threshold = hyperparameters.get("agent_idle_threshold", 6)
     max_iterations = hyperparameters.get("max_iterations", 10)
     max_num_retries = hyperparameters.get("max_num_retries", 3)
+    ratio = hyperparameters.get("ratio", 1.0)
     
     print("\n" + "="*80)
     print("BBMAS (BLACKBOARD MULTI-AGENT SYSTEM) EXPERIMENT")
@@ -719,7 +720,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     print("="*80)
 
     # evaluate all given models on the dev set and select the best one to be the backbone
-    dev_input_list = eval.prepare_inputs(task, task_type, "dev") # grab the inputs for the dev set
+    dev_input_list = eval.prepare_inputs(task, task_type, "dev", ratio=ratio) # grab the inputs for the dev set
 
     list_of_input_list = [dev_input_list for _ in model_names] # replicate the dev inputs for each model
     list_of_output_list = distributed_generation.distributed_generation(
@@ -731,7 +732,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     list_of_dev_scores = []
     for i in range(len(model_names)):
         dev_output_list = list_of_output_list[i]
-        dev_scores = eval.get_scores(task, task_type, "dev", dev_output_list)
+        dev_scores = eval.get_scores(task, task_type, "dev", dev_output_list, ratio=ratio)
         avg_dev_score = sum(dev_scores) / len(dev_scores)
         list_of_dev_scores.append(avg_dev_score)
         print(f"   • Model: {model_names[i]} | Avg Dev Score: {avg_dev_score:.4f}")
@@ -750,7 +751,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     model = AutoModelForCausalLM.from_pretrained(model_name, torch_dtype=torch.bfloat16, device_map="auto")
     # Get test set inputs
     print(f"\n📥 Loading test set...")
-    test_input_list = eval.prepare_inputs(task, task_type, "test")
+    test_input_list = eval.prepare_inputs(task, task_type, "test", ratio=ratio)
     print(f"✓ Loaded {len(test_input_list)} test examples")
     
     # Run BBMAS for each test input
@@ -792,7 +793,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     print(f"\n{'='*80}")
     print(f"EVALUATING ALL TEST EXAMPLES")
     print(f"{'='*80}")
-    test_scores = eval.get_scores(task, task_type, "test", final_output_list)
+    test_scores = eval.get_scores(task, task_type, "test", final_output_list, ratio=ratio)
     avg_test_score = sum(test_scores) / len(test_scores)
     avg_llm_calls = sum(all_llm_calls) / len(all_llm_calls)
     

--- a/model_collaboration/method/text_heterogeneous_swarms.py
+++ b/model_collaboration/method/text_heterogeneous_swarms.py
@@ -228,7 +228,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     patience = hyperparameters.get("patience", 5)
     restart_patience = hyperparameters.get("restart_patience", 3)
 
-    ratio = hyperparameters.get("ratio", 0.25)
+    ratio = hyperparameters.get("ratio", 1.0)
 
     # initialize the swarm
     swarm = NumericSwarm(
@@ -301,7 +301,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     # evaluate the best graph on the test set
     best_graph = swarm.get_global_best_particle().tolist()
     best_adjacency_matrix = list_to_numpy_graph(best_graph)
-    test_input_list = eval.prepare_inputs(task, task_type, "test")
+    test_input_list = eval.prepare_inputs(task, task_type, "test", ratio=ratio)
     test_outputs = graph_generate(
         test_input_list,
         best_adjacency_matrix,
@@ -313,7 +313,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
         batch_size
     )
 
-    test_scores = eval.get_scores(task, task_type, "test", test_outputs)
+    test_scores = eval.get_scores(task, task_type, "test", test_outputs, ratio=ratio)
     avg_test_score = sum(test_scores) / len(test_scores)
     print("H-Swarm test {} score: {}".format(task, avg_test_score))
 

--- a/model_collaboration/method/text_knowledge_card.py
+++ b/model_collaboration/method/text_knowledge_card.py
@@ -12,9 +12,10 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
 
     # method-specific hyperparameters
     exclude_self = hyperparameters.get("exclude_self", False)
+    ratio = hyperparameters.get("ratio", 1.0)
 
     # selecting a model as the final response generator based on performance on the dev set
-    dev_input_list = eval.prepare_inputs(task, task_type, "dev")
+    dev_input_list = eval.prepare_inputs(task, task_type, "dev", ratio=ratio)
     list_of_input_list = [dev_input_list for _ in model_names]
 
     list_of_output_list = distributed_generation.distributed_generation(
@@ -26,7 +27,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     list_of_dev_scores = []
     for i in range(len(model_names)):
         dev_outputs = list_of_output_list[i]
-        dev_score = eval.get_scores(task, task_type, "dev", dev_outputs)
+        dev_score = eval.get_scores(task, task_type, "dev", dev_outputs, ratio=ratio)
         avg_dev_score = sum(dev_score) / len(dev_score)
         list_of_dev_scores.append(avg_dev_score)
         print("Model: {}, dev {} score: {}".format(model_names[i], task, avg_dev_score))
@@ -36,7 +37,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     print("Best model selected for final summarization: {}".format(best_model_name))
 
     # generaing relevant knowledge on the test set from all models
-    test_input_list = eval.prepare_inputs(task, task_type, "test")
+    test_input_list = eval.prepare_inputs(task, task_type, "test", ratio=ratio)
     knowledge_generation_prompt = []
     for input_text in test_input_list:
         prompt = "You are an AI assistant tasked with generating relevant knowledge to help answer the user's question. Please provide relevant information that can assist in answering the following question:\n\n"
@@ -70,7 +71,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
         [gpu_ids[0]]
     )[0]
 
-    test_scores = eval.get_scores(task, task_type, "test", final_outputs)
+    test_scores = eval.get_scores(task, task_type, "test", final_outputs, ratio=ratio)
     avg_test_score = sum(test_scores) / len(test_scores)
     print("Final test {} score after knowledge card: {}".format(task, avg_test_score))
 

--- a/model_collaboration/method/text_llm_blender.py
+++ b/model_collaboration/method/text_llm_blender.py
@@ -75,7 +75,7 @@ def _build_pairwise_ranking_prompt(
     return prompt
 
 
-def _collect_dev_candidates_and_scores(task, task_type, gpu_ids, model_names):
+def _collect_dev_candidates_and_scores(task, task_type, gpu_ids, model_names, ratio=1.0):
     """
     Generate dev-set candidates and task scores for each model.
     Returns:
@@ -83,7 +83,7 @@ def _collect_dev_candidates_and_scores(task, task_type, gpu_ids, model_names):
         dev_candidates: List[List[str]]  # per example: list over models
         dev_scores: List[List[float]]    # per example: list over models
     """
-    dev_inputs = eval.prepare_inputs(task, task_type, "dev")
+    dev_inputs = eval.prepare_inputs(task, task_type, "dev", ratio=ratio)
     if not dev_inputs:
         return [], [], []
 
@@ -100,7 +100,7 @@ def _collect_dev_candidates_and_scores(task, task_type, gpu_ids, model_names):
     dev_scores_per_model = []
     for i in range(num_models):
         dev_outputs_i = list_of_output_list[i]
-        scores_i = eval.get_scores(task, task_type, "dev", dev_outputs_i)
+        scores_i = eval.get_scores(task, task_type, "dev", dev_outputs_i, ratio=ratio)
         dev_scores_per_model.append(scores_i)
 
     dev_candidates = []
@@ -610,6 +610,8 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     os.makedirs("model_collaboration/logs", exist_ok=True)
     os.makedirs(METHOD_LOG_DIR, exist_ok=True)
 
+    ratio = hyperparameters.get("ratio", 1.0)
+
     # Optional training on dev set
     trained_ranker_path = None
     trained_fuser_path = None
@@ -618,7 +620,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     ):
         print("[LLM-Blender] Collecting dev candidates and scores for training...")
         dev_inputs, dev_candidates, dev_scores = _collect_dev_candidates_and_scores(
-            task, task_type, gpu_ids, model_names
+            task, task_type, gpu_ids, model_names, ratio=ratio
         )
         if hyperparameters.get("train_ranker_on_dev", False):
             trained_ranker_path = _train_ranker_on_dev(
@@ -644,7 +646,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
             )
 
     # Prepare test inputs
-    test_input_list = eval.prepare_inputs(task, task_type, "test")
+    test_input_list = eval.prepare_inputs(task, task_type, "test", ratio=ratio)
 
     # Step 1: generate candidate answers from each base model
     print(f"[LLM-Blender] Generating candidate answers from {len(model_names)} base models: {model_names}")
@@ -681,7 +683,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
 
     # Evaluation
     print("[LLM-Blender] Evaluating fused outputs on the test set...")
-    test_scores = eval.get_scores(task, task_type, "test", final_outputs)
+    test_scores = eval.get_scores(task, task_type, "test", final_outputs, ratio=ratio)
     avg_test_score = sum(test_scores) / len(test_scores) if test_scores else 0.0
     print(
         f"[LLM-Blender] Final test {task} score with {len(model_names)} models: {avg_test_score}"

--- a/model_collaboration/method/text_majority_vote.py
+++ b/model_collaboration/method/text_majority_vote.py
@@ -75,7 +75,7 @@ def get_scores_from_extracted_answers(task, task_type, split, extracted_answers,
                 scores.append(f1_score)
     return scores
 
-def evaluate_models_on_dev(task, task_type, model_indices, model_names, gpu_ids, dev_scores_cache, dev_input_list):
+def evaluate_models_on_dev(task, task_type, model_indices, model_names, gpu_ids, dev_scores_cache, dev_input_list, ratio=1.0):
 
     # find models that need evaluation
     models_to_evaluate = [i for i in model_indices if i not in dev_scores_cache]
@@ -95,7 +95,7 @@ def evaluate_models_on_dev(task, task_type, model_indices, model_names, gpu_ids,
     # cache the scores
     for idx, model_idx in enumerate(models_to_evaluate):
         dev_outputs = list_of_output_list[idx]
-        dev_score = eval.get_scores(task, task_type, "dev", dev_outputs)
+        dev_score = eval.get_scores(task, task_type, "dev", dev_outputs, ratio=ratio)
         avg_dev_score = sum(dev_score) / len(dev_score)
         dev_scores_cache[model_idx] = avg_dev_score
         print("Model: {} (index {}), dev {} score: {}".format(model_names[model_idx], model_idx, task, avg_dev_score))
@@ -112,13 +112,14 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
 
     tie_breaking = hyperparameters.get("tie", "random")
     assert tie_breaking in ["random", "dev-based"], "tie parameter must be either 'random' or 'dev-based'"
+    ratio = hyperparameters.get("ratio", 1.0)
 
     if tie_breaking == "dev-based":
-        dev_input_list = eval.prepare_inputs(task, task_type, "dev")
+        dev_input_list = eval.prepare_inputs(task, task_type, "dev", ratio=ratio)
         dev_scores_cache = {}
 
     # evaluate on the test set
-    test_input_list = eval.prepare_inputs(task, task_type, "test") # grab the inputs for the test set
+    test_input_list = eval.prepare_inputs(task, task_type, "test", ratio=ratio) # grab the inputs for the test set
 
     list_of_input_list = [test_input_list for _ in model_names] # replicate the test inputs for each model
     list_of_output_list = distributed_generation.distributed_generation(
@@ -129,7 +130,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     
     list_of_extracted_answers = []
     for output_list in list_of_output_list:
-        extracted_answers = get_extracted_answers(task, task_type, "test", output_list)
+        extracted_answers = get_extracted_answers(task, task_type, "test", output_list, ratio=ratio)
         list_of_extracted_answers.append(extracted_answers)
     
     majority_vote_answers = []
@@ -153,8 +154,8 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
             
             # evaluate tied models on dev set (only if not already cached)
             evaluate_models_on_dev(
-                task, task_type, tied_model_indices, model_names, gpu_ids, 
-                dev_scores_cache, dev_input_list
+                task, task_type, tied_model_indices, model_names, gpu_ids,
+                dev_scores_cache, dev_input_list, ratio=ratio
             )
             
             # find the best-performing model (on dev set) among those that voted for tied answers
@@ -162,7 +163,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
             majority_vote_answers.append(extracted_answers[best_tied_model_index])
     
     # evaluate the final outputs
-    test_scores = get_scores_from_extracted_answers(task, task_type, "test", majority_vote_answers)
+    test_scores = get_scores_from_extracted_answers(task, task_type, "test", majority_vote_answers, ratio=ratio)
     avg_test_score = sum(test_scores) / len(test_scores)
     print("Final test {} score of majority vote: {}".format(task, avg_test_score))
 

--- a/model_collaboration/method/text_multiagent_feedback.py
+++ b/model_collaboration/method/text_multiagent_feedback.py
@@ -31,9 +31,10 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     # method-specific hyperparameters
     rounds = hyperparameters.get("round", 3)
     feedback_count = hyperparameters.get("feedback_count", 3)
+    ratio = hyperparameters.get("ratio", 1.0)
 
     # selecting a model as the final summarizer based on performance on the dev set
-    dev_input_list = eval.prepare_inputs(task, task_type, "dev")
+    dev_input_list = eval.prepare_inputs(task, task_type, "dev", ratio=ratio)
     list_of_input_list = [dev_input_list for _ in model_names]
 
     list_of_output_list = distributed_generation.distributed_generation(
@@ -45,7 +46,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     list_of_dev_scores = []
     for i in range(len(model_names)):
         dev_outputs = list_of_output_list[i]
-        dev_score = eval.get_scores(task, task_type, "dev", dev_outputs)
+        dev_score = eval.get_scores(task, task_type, "dev", dev_outputs, ratio=ratio)
         avg_dev_score = sum(dev_score) / len(dev_score)
         list_of_dev_scores.append(avg_dev_score)
         print("Model: {}, dev {} score: {}".format(model_names[i], task_type, avg_dev_score))
@@ -55,7 +56,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     print("Best model selected for final summarization: {}".format(best_model_name))
 
     # multiagent feedback on the test set
-    test_input_list = eval.prepare_inputs(task, task_type, "test")
+    test_input_list = eval.prepare_inputs(task, task_type, "test", ratio=ratio)
     response_list = None # len(model_names) * len(test_input_list)
     for r in range(rounds):
         print("Round {}/{}".format(r+1, rounds))
@@ -144,7 +145,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
         list_of_gpu_ids
     )
     final_outputs = list_of_output_list[0]
-    test_scores = eval.get_scores(task, task_type, "test", final_outputs)
+    test_scores = eval.get_scores(task, task_type, "test", final_outputs, ratio=ratio)
     avg_test_score = sum(test_scores) / len(test_scores)
     print("Final Test {} score after {} rounds of multiagent feedback: {}".format(task, rounds, avg_test_score))
 

--- a/model_collaboration/method/text_multiagent_finetuning.py
+++ b/model_collaboration/method/text_multiagent_finetuning.py
@@ -200,6 +200,7 @@ def run_method(task: str,
     rounds = int(hyperparameters.get("rounds", 2))
     w = float(hyperparameters.get("w", 0.5))
     training_ratio = float(hyperparameters.get("training_ratio", 1.0))
+    ratio = hyperparameters.get("ratio", 1.0)
     # SFT hyperparameters
     sft_epochs = int(hyperparameters.get("sft_epochs", 1))
     sft_learning_rate = float(hyperparameters.get("sft_learning_rate", 1e-5))
@@ -221,7 +222,7 @@ def run_method(task: str,
         full_data = json.load(f_data)
     dev_data_full = full_data.get("dev", [])
     # Format questions using helper
-    dev_inputs_full = eval.prepare_inputs(task, task_type, "dev")
+    dev_inputs_full = eval.prepare_inputs(task, task_type, "dev", ratio=ratio)
     assert len(dev_inputs_full) == len(dev_data_full), "Mismatch between dev inputs and data length"
     if training_ratio < 1.0:
         n_total = len(dev_inputs_full)
@@ -523,7 +524,7 @@ def run_method(task: str,
     # After completing all iterations, evaluate on the test set using the
     # finetuned models in a debate format
     print("\nEvaluating finetuned models on test set...")
-    test_inputs = eval.prepare_inputs(task, task_type, "test")
+    test_inputs = eval.prepare_inputs(task, task_type, "test", ratio=ratio)
     N = len(current_generation_models)
     # Round 0: generation
     list_of_input_list = [test_inputs for _ in range(N)]
@@ -586,7 +587,7 @@ def run_method(task: str,
         consensus = _majority_vote(extracted_list)
         final_outputs_extracted.append(consensus)
     # Evaluate using extracted answers; eval.get_scores handles parsing internally
-    test_scores = eval.get_scores(task, task_type, "test", final_outputs_extracted)
+    test_scores = eval.get_scores(task, task_type, "test", final_outputs_extracted, ratio=ratio)
     avg_test_score = sum(test_scores) / len(test_scores) if test_scores else 0.0
     print(f"Final Test {task} score after {iterations} finetuning iteration(s): {avg_test_score}")
     # Log results

--- a/model_collaboration/method/text_multiagent_refine.py
+++ b/model_collaboration/method/text_multiagent_refine.py
@@ -12,9 +12,10 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
 
     # method-specific hyperparameters
     rounds = hyperparameters.get("round", 3)
+    ratio = hyperparameters.get("ratio", 1.0)
 
     # selecting a model as the final summarizer based on performance on the dev set
-    dev_input_list = eval.prepare_inputs(task, task_type, "dev")
+    dev_input_list = eval.prepare_inputs(task, task_type, "dev", ratio=ratio)
     list_of_input_list = [dev_input_list for _ in model_names]
 
     list_of_output_list = distributed_generation.distributed_generation(
@@ -26,7 +27,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     list_of_dev_scores = []
     for i in range(len(model_names)):
         dev_outputs = list_of_output_list[i]
-        dev_score = eval.get_scores(task, task_type, "dev", dev_outputs)
+        dev_score = eval.get_scores(task, task_type, "dev", dev_outputs, ratio=ratio)
         avg_dev_score = sum(dev_score) / len(dev_score)
         list_of_dev_scores.append(avg_dev_score)
         print("Model: {}, dev {} score: {}".format(model_names[i], task, avg_dev_score))
@@ -36,7 +37,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     print("Best model selected for final summarization: {}".format(best_model_name))
 
     # multiagent refine on the test set
-    test_input_list = eval.prepare_inputs(task, task_type, "test")
+    test_input_list = eval.prepare_inputs(task, task_type, "test", ratio=ratio)
     response_list = None # len(model_names) * len(test_input_list)
     for r in range(rounds):
         print("Round {}/{}".format(r+1, rounds))
@@ -90,7 +91,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
         list_of_gpu_ids
     )
     final_outputs = list_of_output_list[0]
-    test_scores = eval.get_scores(task, task_type, "test", final_outputs)
+    test_scores = eval.get_scores(task, task_type, "test", final_outputs, ratio=ratio)
     avg_test_score = sum(test_scores) / len(test_scores)
     print("Final Test {} score after {} rounds of multiagent refine: {}".format(task, rounds, avg_test_score))
 

--- a/model_collaboration/method/text_slm_mux.py
+++ b/model_collaboration/method/text_slm_mux.py
@@ -70,24 +70,25 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
         "tie must be one of 'dev-based', 'model-order', 'random'"
     )
     seed = int(hyperparameters.get("seed", 42))
+    ratio = hyperparameters.get("ratio", 1.0)
     random.seed(seed)
 
     # 1. (Optional) compute per-model dev accuracy for tie-breaking
     model_accuracies = {}
     if tie_breaking == "dev-based":
-        dev_inputs = eval.prepare_inputs(task, task_type, "dev")
+        dev_inputs = eval.prepare_inputs(task, task_type, "dev", ratio=ratio)
         list_of_inputs = [dev_inputs for _ in model_names]
         dev_outputs = distributed_generation.distributed_generation(
             model_names, list_of_inputs, gpu_ids
         )
         for i, name in enumerate(model_names):
-            scores = eval.get_scores(task, task_type, "dev", dev_outputs[i])
+            scores = eval.get_scores(task, task_type, "dev", dev_outputs[i], ratio=ratio)
             acc = sum(scores) / len(scores) if scores else 0.0
             model_accuracies[name] = acc
             print("[SLM-MUX] dev accuracy for {}: {:.4f}".format(name, acc))
 
     # 2. Generate k samples per model on the test set
-    test_inputs = eval.prepare_inputs(task, task_type, "test")
+    test_inputs = eval.prepare_inputs(task, task_type, "test", ratio=ratio)
     print("[SLM-MUX] generating k={} samples per model on {} test items".format(
         samples_per_model, len(test_inputs)
     ))
@@ -100,7 +101,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     for mi in range(len(model_names)):
         per_sample_ans, per_sample_scores = [], []
         for s in range(samples_per_model):
-            sc, ps = eval.get_scores(task, task_type, "test", samples[mi][s], return_output=True)
+            sc, ps = eval.get_scores(task, task_type, "test", samples[mi][s], ratio=ratio, return_output=True)
             per_sample_ans.append(ps)
             per_sample_scores.append(sc)
         extracted.append(per_sample_ans)

--- a/model_collaboration/method/text_sparta.py
+++ b/model_collaboration/method/text_sparta.py
@@ -1247,6 +1247,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     score_type = hyperparameters.get("score_type", "normal")  # normal / dynamic / static
     freeze_ratings = bool(hyperparameters.get("freeze_ratings", False))
     debug = bool(hyperparameters.get("debug", False))
+    ratio = hyperparameters.get("ratio", 1.0)
 
     # Track current model paths (for adapter handling across iterations)
     # model_names are already HuggingFace identifiers, use them directly
@@ -1288,7 +1289,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
                 pass
 
         # ------------------------- 3. Prepare dev instructions -------------------------
-        all_instructions = eval.prepare_inputs(task, task_type, "dev")
+        all_instructions = eval.prepare_inputs(task, task_type, "dev", ratio=ratio)
         if num_instructions < len(all_instructions):
             instructions = all_instructions[:num_instructions]
         else:
@@ -1611,7 +1612,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     # If no adapters were found (e.g., no preference_pairs), fall back to using the final current_model_paths
     if not all_adapter_entries:
         print("[Sparta] No DPO adapters found across iterations; falling back to final models only.")
-        dev_input_list = eval.prepare_inputs(task, task_type, "dev")
+        dev_input_list = eval.prepare_inputs(task, task_type, "dev", ratio=ratio)
         list_of_input_list = [dev_input_list for _ in model_names]
         final_model_paths = [current_model_paths.get(m, m) for m in model_names]
         list_of_output_list = distributed_generation.distributed_generation(
@@ -1623,7 +1624,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
         list_of_dev_scores = []
         for i in range(len(model_names)):
             dev_outputs = list_of_output_list[i]
-            dev_score = eval.get_scores(task, task_type, "dev", dev_outputs)
+            dev_score = eval.get_scores(task, task_type, "dev", dev_outputs, ratio=ratio)
             avg_dev_score = sum(dev_score) / len(dev_score)
             list_of_dev_scores.append(avg_dev_score)
             print(f"[Sparta] Final model {model_names[i]}: dev {task} score: {avg_dev_score}")
@@ -1642,7 +1643,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
         }
     else:
         # 2) Evaluate every (iteration, model, adapter_path) on dev set
-        dev_input_list = eval.prepare_inputs(task, task_type, "dev")
+        dev_input_list = eval.prepare_inputs(task, task_type, "dev", ratio=ratio)
         list_of_input_list = [dev_input_list for _ in all_adapter_entries]
         adapter_paths = [entry[2] for entry in all_adapter_entries]
 
@@ -1659,7 +1660,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
         for idx, ((it, m, path), outputs) in enumerate(
             zip(all_adapter_entries, list_of_output_list)
         ):
-            dev_score = eval.get_scores(task, task_type, "dev", outputs)
+            dev_score = eval.get_scores(task, task_type, "dev", outputs, ratio=ratio)
             avg_dev_score = sum(dev_score) / len(dev_score)
             adapter_dev_scores.append(avg_dev_score)
             key = f"{m}_iter{it}"
@@ -1678,7 +1679,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
         )
     
     # 4) Evaluate best model on test set
-    test_input_list = eval.prepare_inputs(task, task_type, "test")
+    test_input_list = eval.prepare_inputs(task, task_type, "test", ratio=ratio)
     test_output_list = distributed_generation.distributed_generation(
         [best_model_path],
         [test_input_list],
@@ -1687,7 +1688,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     final_output_list = test_output_list[0]
     
     # Evaluate the final outputs
-    test_scores = eval.get_scores(task, task_type, "test", final_output_list)
+    test_scores = eval.get_scores(task, task_type, "test", final_output_list, ratio=ratio)
     avg_test_score = sum(test_scores) / len(test_scores)
     print(f"[Sparta] Final test {task} score: {avg_test_score}")
     

--- a/model_collaboration/method/text_structure.py
+++ b/model_collaboration/method/text_structure.py
@@ -110,6 +110,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
         print("Warning: num_rounds is 1, which means no interaction between models will happen.")
     structure_type = hyperparameters.get("structure_type", "not_supported")
     structure_matrix = hyperparameters.get("structure_matrix", None)
+    ratio = hyperparameters.get("ratio", 1.0)
     assert structure_type in ["chain", "tree", "star", "circle", "complete", "other"], "Invalid structure type, please provide one of the supported types: chain, tree, star, circle, complete, other."
     if structure_type == "other":
         assert structure_matrix is not None, "Please provide a structure matrix (list of lists of size num_models x num_models) for 'other' structure type."
@@ -136,7 +137,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
 
     # 3. select best model for final score based on the dev set of the dataset
     print("Evaluating models on dev set to select the best model...")
-    dev_input_list = eval.prepare_inputs(task, task_type, "dev") # grab the inputs for the dev set
+    dev_input_list = eval.prepare_inputs(task, task_type, "dev", ratio=ratio) # grab the inputs for the dev set
     # evaluate every model on it through distributed generation
     list_of_input_list = [dev_input_list for _ in model_names] # replicate the dev inputs for each model
     list_of_output_list = distributed_generation.distributed_generation(
@@ -148,7 +149,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     list_of_dev_scores = []
     for i in range(len(model_names)):
         dev_outputs = list_of_output_list[i]
-        dev_score = eval.get_scores(task, task_type, "dev", dev_outputs) # send the outputs to the eval module to get a list of per-input scores
+        dev_score = eval.get_scores(task, task_type, "dev", dev_outputs, ratio=ratio) # send the outputs to the eval module to get a list of per-input scores
         avg_dev_score = sum(dev_score) / len(dev_score)
         list_of_dev_scores.append(avg_dev_score)
         print("Model: {}, dev {} score: {}".format(model_names[i], task, avg_dev_score))
@@ -160,7 +161,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
 
     # start the multi-round interaction between models
     print("Round 0: Starting multi-round interaction by generating initial outputs with each model...")
-    test_input_list = eval.prepare_inputs(task, task_type, "test") # grab the inputs for the test set
+    test_input_list = eval.prepare_inputs(task, task_type, "test", ratio=ratio) # grab the inputs for the test set
     # evaluate every model on it through distributed generation
     list_of_input_list = [test_input_list for _ in model_names] # replicate the test inputs for each model
     list_of_output_list = distributed_generation.distributed_generation(
@@ -220,7 +221,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     for i in range(len(model_names)):
         # print("Final outputs from model {}: {}".format(model_names[i], all_output_list[-1][i][:2])) # print first 3 outputs as a sample
         cur_test_outputs = all_output_list[-1][i]
-        cur_test_score = eval.get_scores(task, task_type, "test", cur_test_outputs) #
+        cur_test_score = eval.get_scores(task, task_type, "test", cur_test_outputs, ratio=ratio) #
         cur_avg_test_score = sum(cur_test_score) / len(cur_test_score)
         test_scores_dict[model_names[i]] = cur_avg_test_score
         if model_names[i] == best_model_name:

--- a/model_collaboration/method/weight_dare_ties.py
+++ b/model_collaboration/method/weight_dare_ties.py
@@ -51,6 +51,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     minimum_step_length = hyperparameters.get("minimum_step_length", 0.1)
     patience = hyperparameters.get("patience", 5)
     restart_patience = hyperparameters.get("restart_patience", 3)
+    ratio = hyperparameters.get("ratio", 1.0)
 
     if mode == "optimized":
 
@@ -72,7 +73,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
         )
 
         # optimize the weights of model merging on the dev set
-        dev_input_list = eval.prepare_inputs(task, task_type, "dev")
+        dev_input_list = eval.prepare_inputs(task, task_type, "dev", ratio=ratio)
         for iteration in range(max_iterations):
             population_of_weights = swarm.get_particles() # [tensor(len(model_names)), ...]
             # softmax to ensure weights sum to 1
@@ -109,7 +110,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
             dev_scores = []
             for i in range(len(list_of_output_list)):
                 dev_output = list_of_output_list[i]
-                dev_score = eval.get_scores(task, task_type, "dev", dev_output)
+                dev_score = eval.get_scores(task, task_type, "dev", dev_output, ratio=ratio)
                 avg_dev_score = sum(dev_score) / len(dev_score)
                 dev_scores.append(avg_dev_score)
                 print("Iteration {}, particle {}: dev {} score: {}".format(iteration, i, task, avg_dev_score))
@@ -146,7 +147,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     # os.system("mergekit-yaml " + dare_ties_base_path + "dare_ties.yml " + merged_model_path + " --cuda --device cuda:" + str(gpu_ids[0]))
     
     # evaluate it on the test set
-    test_input_list = eval.prepare_inputs(task, task_type, "test")
+    test_input_list = eval.prepare_inputs(task, task_type, "test", ratio=ratio)
     list_of_input_list = [test_input_list]
     list_of_output_list = distributed_generation.distributed_generation(
         [merged_model_path],
@@ -155,7 +156,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     )
 
     test_outputs = list_of_output_list[0]
-    test_score = eval.get_scores(task, task_type, "test", test_outputs)
+    test_score = eval.get_scores(task, task_type, "test", test_outputs, ratio=ratio)
     avg_test_score = sum(test_score) / len(test_score)
     print("dare-ties test {} score: {}".format(task, avg_test_score))
 

--- a/model_collaboration/method/weight_expo.py
+++ b/model_collaboration/method/weight_expo.py
@@ -147,7 +147,8 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     alpha_mode = hyperparameters.get("alpha_mode", "fixed")
     alpha_candidates = hyperparameters.get("alpha_candidates", [0.1, 0.2, 0.3, 0.4, 0.5])
     k = hyperparameters.get("k", 1)
-    
+    ratio = hyperparameters.get("ratio", 1.0)
+
     # Create output directory
     expo_base_path = hyperparameters.get("expo_base_path", "model_collaboration/logs/expo/")
     expo_base_path = expo_base_path.rstrip("/") + "_" + task + "/"
@@ -167,8 +168,8 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     print("Step 1: Evaluating all models on dev set")
     print("=" * 60)
     
-    dev_input_list = eval.prepare_inputs(task, task_type, "dev")
-    
+    dev_input_list = eval.prepare_inputs(task, task_type, "dev", ratio=ratio)
+
     list_of_input_list = [dev_input_list for _ in model_names]
     list_of_output_list = distributed_generation.distributed_generation(
         model_names,
@@ -180,7 +181,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     model_scores = []
     for i, model_name in enumerate(model_names):
         dev_outputs = list_of_output_list[i]
-        dev_scores = eval.get_scores(task, task_type, "dev", dev_outputs)
+        dev_scores = eval.get_scores(task, task_type, "dev", dev_outputs, ratio=ratio)
         avg_dev_score = sum(dev_scores) / len(dev_scores)
         model_scores.append(avg_dev_score)
         print(f"Model {i + 1} ({model_name}): dev {task} score = {avg_dev_score:.4f}")
@@ -278,9 +279,9 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
             )
             
             dev_outputs = list_of_output_list[0]
-            dev_scores = eval.get_scores(task, task_type, "dev", dev_outputs)
+            dev_scores = eval.get_scores(task, task_type, "dev", dev_outputs, ratio=ratio)
             avg_dev_score = sum(dev_scores) / len(dev_scores)
-            
+
             print(f"Alpha {candidate_alpha}: dev {task} score = {avg_dev_score:.4f}")
             
             if avg_dev_score > best_dev_score:
@@ -322,16 +323,16 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
         except:
             pass
     
-    test_input_list = eval.prepare_inputs(task, task_type, "test")
-    
+    test_input_list = eval.prepare_inputs(task, task_type, "test", ratio=ratio)
+
     list_of_output_list = distributed_generation.distributed_generation(
         [final_model_path],
         [test_input_list],
         [gpu_ids[0]]
     )
-    
+
     test_outputs = list_of_output_list[0]
-    test_scores = eval.get_scores(task, task_type, "test", test_outputs)
+    test_scores = eval.get_scores(task, task_type, "test", test_outputs, ratio=ratio)
     avg_test_score = sum(test_scores) / len(test_scores)
     
     print(f"\n{'=' * 60}")
@@ -407,6 +408,7 @@ def run_pairs_mode(task, task_type, gpu_ids, model_names, hyperparameters, expo_
     alpha_mode = hyperparameters.get("alpha_mode", "fixed")
     alpha_candidates = hyperparameters.get("alpha_candidates", [0.1, 0.2, 0.3, 0.4, 0.5])
     pair_selection = hyperparameters.get("pair_selection", "dpo_score")
+    ratio = hyperparameters.get("ratio", 1.0)
     gpu_id = gpu_ids[0]
     
     # Evaluate all models if multiple pairs
@@ -415,8 +417,8 @@ def run_pairs_mode(task, task_type, gpu_ids, model_names, hyperparameters, expo_
         print("Evaluating all models on dev set to select best pair")
         print("=" * 60)
         
-        dev_input_list = eval.prepare_inputs(task, task_type, "dev")
-        
+        dev_input_list = eval.prepare_inputs(task, task_type, "dev", ratio=ratio)
+
         all_model_paths = []
         for sft, dpo in pairs:
             all_model_paths.extend([sft, dpo])
@@ -431,7 +433,7 @@ def run_pairs_mode(task, task_type, gpu_ids, model_names, hyperparameters, expo_
         all_dev_scores = []
         for i, model_path in enumerate(all_model_paths):
             dev_outputs = list_of_output_list[i]
-            dev_scores = eval.get_scores(task, task_type, "dev", dev_outputs)
+            dev_scores = eval.get_scores(task, task_type, "dev", dev_outputs, ratio=ratio)
             avg_dev_score = sum(dev_scores) / len(dev_scores)
             all_dev_scores.append(avg_dev_score)
             model_type = "source" if i % 2 == 0 else "target"
@@ -466,7 +468,7 @@ def run_pairs_mode(task, task_type, gpu_ids, model_names, hyperparameters, expo_
     
     # Optimize alpha if needed
     if alpha_mode == "optimized":
-        dev_input_list = eval.prepare_inputs(task, task_type, "dev")
+        dev_input_list = eval.prepare_inputs(task, task_type, "dev", ratio=ratio)
         best_alpha = alpha_candidates[0]
         best_dev_score = -float("inf")
         
@@ -478,9 +480,9 @@ def run_pairs_mode(task, task_type, gpu_ids, model_names, hyperparameters, expo_
                 [extrapolated_model_path], [dev_input_list], [gpu_id]
             )
             dev_outputs = list_of_output_list[0]
-            dev_scores = eval.get_scores(task, task_type, "dev", dev_outputs)
+            dev_scores = eval.get_scores(task, task_type, "dev", dev_outputs, ratio=ratio)
             avg_dev_score = sum(dev_scores) / len(dev_scores)
-            
+
             print(f"Alpha {candidate_alpha}: dev score = {avg_dev_score:.4f}")
             if avg_dev_score > best_dev_score:
                 best_dev_score = avg_dev_score
@@ -498,13 +500,13 @@ def run_pairs_mode(task, task_type, gpu_ids, model_names, hyperparameters, expo_
     gc.collect()
     torch.cuda.empty_cache()
     
-    test_input_list = eval.prepare_inputs(task, task_type, "test")
+    test_input_list = eval.prepare_inputs(task, task_type, "test", ratio=ratio)
     list_of_output_list = distributed_generation.distributed_generation(
         [final_model_path], [test_input_list], [gpu_ids[0]]
     )
-    
+
     test_outputs = list_of_output_list[0]
-    test_scores = eval.get_scores(task, task_type, "test", test_outputs)
+    test_scores = eval.get_scores(task, task_type, "test", test_outputs, ratio=ratio)
     avg_test_score = sum(test_scores) / len(test_scores)
     
     print(f"\nExPO test {task} score: {avg_test_score:.4f} (alpha={alpha})")

--- a/model_collaboration/method/weight_greedy_soup.py
+++ b/model_collaboration/method/weight_greedy_soup.py
@@ -22,8 +22,10 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     # checking if the models are lora adapters
     model_names = lora_check.lora_to_full(model_names)
 
+    ratio = hyperparameters.get("ratio", 1.0)
+
     # evaluating the models and rank them by dev set performance
-    dev_input_list = eval.prepare_inputs(task, task_type, "dev")
+    dev_input_list = eval.prepare_inputs(task, task_type, "dev", ratio=ratio)
     list_of_input_list = [dev_input_list for _ in model_names]
 
     list_of_output_list = distributed_generation.distributed_generation(
@@ -35,7 +37,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     list_of_dev_scores = []
     for i in range(len(model_names)):
         dev_outputs = list_of_output_list[i]
-        dev_score = eval.get_scores(task, task_type, "dev", dev_outputs)
+        dev_score = eval.get_scores(task, task_type, "dev", dev_outputs, ratio=ratio)
         avg_dev_score = sum(dev_score) / len(dev_score)
         list_of_dev_scores.append(avg_dev_score)
         print("Model: {}, dev {} score: {}".format(model_names[i], task, avg_dev_score))
@@ -72,7 +74,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
             [gpu_ids[0]]
         )
         dev_outputs = list_of_output_list[0]
-        dev_score = eval.get_scores(task, task_type, "dev", dev_outputs)
+        dev_score = eval.get_scores(task, task_type, "dev", dev_outputs, ratio=ratio)
         avg_dev_score = sum(dev_score) / len(dev_score)
         print("Evaluating greedy soup with models {}: dev {} score: {}".format(current_selected_models, task, avg_dev_score))
         if avg_dev_score >= current_best_score:
@@ -90,7 +92,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
         print("Only one model selected, using the model: {}".format(final_model_name))
 
         # evaluate it on the test set
-        test_input_list = eval.prepare_inputs(task, task_type, "test")
+        test_input_list = eval.prepare_inputs(task, task_type, "test", ratio=ratio)
         list_of_input_list = [test_input_list]
         list_of_output_list = distributed_generation.distributed_generation(
             [final_model_name],
@@ -113,7 +115,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
         )
 
         # evaluate it on the test set
-        test_input_list = eval.prepare_inputs(task, task_type, "test")
+        test_input_list = eval.prepare_inputs(task, task_type, "test", ratio=ratio)
         list_of_input_list = [test_input_list]
         list_of_output_list = distributed_generation.distributed_generation(
             ["model_collaboration/logs/greedy_soup"],
@@ -122,7 +124,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
         )
 
     test_outputs = list_of_output_list[0]
-    test_score = eval.get_scores(task, task_type, "test", test_outputs)
+    test_score = eval.get_scores(task, task_type, "test", test_outputs, ratio=ratio)
     avg_test_score = sum(test_score) / len(test_score)
     print("Greedy soup test {} score: {}".format(task, avg_test_score))
 

--- a/model_collaboration/method/weight_lorahub.py
+++ b/model_collaboration/method/weight_lorahub.py
@@ -62,7 +62,7 @@ def default_l1_regularization(weights, coef):
     sum_of_squares = sum([abs(x) for x in weights]) / len(weights)
     return coef * sum_of_squares
 
-def get_score_by_generation(weights, model, tokenizer, cache, input_texts, task, task_type, device, max_new_tokens, regular_coef):
+def get_score_by_generation(weights, model, tokenizer, cache, input_texts, task, task_type, device, max_new_tokens, regular_coef, ratio=1.0):
     """Optimization objective: Merge weights -> Generate -> Score."""
     # Synthesize Weights
     final_state_dict = {}
@@ -97,7 +97,7 @@ def get_score_by_generation(weights, model, tokenizer, cache, input_texts, task,
     
     # Evaluate
     try:
-        scores = eval.get_scores(task, task_type, "dev", decoded_outputs)
+        scores = eval.get_scores(task, task_type, "dev", decoded_outputs, ratio=ratio)
         avg_score = sum(scores) / len(scores)
     except Exception as e:
         print(f"Error during scoring: {e}")
@@ -156,8 +156,9 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     lora_weight_bound = hyperparameters.get("lora_weight_bound", 1.5)
     regular_coef = hyperparameters.get("regular_coef", 0.05)
     max_response_length = hyperparameters.get("max_response_length", 256)
-    test_batch_size = hyperparameters.get("batch_size", 4) 
+    test_batch_size = hyperparameters.get("batch_size", 4)
     if test_batch_size is None: test_batch_size = 4
+    ratio = hyperparameters.get("ratio", 1.0)
 
     random.seed(seed)
     np.random.seed(seed)
@@ -168,7 +169,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
         if not lora_check.is_lora_adapter_peft(model_name):
             raise ValueError("Model {} is not a LoRA adapter".format(model_name))
             
-    dev_input_list = eval.prepare_inputs(task, task_type, "dev")[:lorahub_dev_samples]
+    dev_input_list = eval.prepare_inputs(task, task_type, "dev", ratio=ratio)[:lorahub_dev_samples]
     base_model_path = PeftConfig.from_pretrained(model_names[0]).base_model_name_or_path
     device = f"cuda:{gpu_ids[0]}" if torch.cuda.is_available() and gpu_ids else "cpu"
 
@@ -181,7 +182,8 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
         get_score_by_generation, 
         model=model, tokenizer=tokenizer, cache=cache, 
         input_texts=dev_input_list, task=task, task_type=task_type, 
-        device=device, max_new_tokens=max_response_length, regular_coef=regular_coef
+        device=device, max_new_tokens=max_response_length, regular_coef=regular_coef,
+        ratio=ratio
     )
 
     instrum = ng.p.Array(
@@ -228,8 +230,8 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     # =========================================================================
     # Run inference on the full test set using the optimized model.
     print("> Evaluating optimized model on Test Set ...")
-    test_input_list = eval.prepare_inputs(task, task_type, "test")
-    
+    test_input_list = eval.prepare_inputs(task, task_type, "test", ratio=ratio)
+
     test_outputs = inference_on_test_set(
         model=model,
         tokenizer=tokenizer,
@@ -240,7 +242,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     )
 
     # Score the results
-    test_score = eval.get_scores(task, task_type, "test", test_outputs)
+    test_score = eval.get_scores(task, task_type, "test", test_outputs, ratio=ratio)
     avg_test_score = sum(test_score) / len(test_score)
     print("LoRAHub test {} score: {}".format(task, avg_test_score))
 

--- a/model_collaboration/method/weight_model_swarms.py
+++ b/model_collaboration/method/weight_model_swarms.py
@@ -43,6 +43,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     patience = hyperparameters.get("patience", 5)
     restart_patience = hyperparameters.get("restart_patience", 3)
     max_iterations = hyperparameters.get("max_iterations", 10)
+    ratio = hyperparameters.get("ratio", 1.0)
 
     # initialize the swarm
     model_swarm = swarm.Swarm(
@@ -70,7 +71,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
         print("Swarm optimization iteration {}/{}".format(iter+1, max_iterations))
         
         # evaluate the swarm of models on the dev set
-        dev_input_list = eval.prepare_inputs(task, task_type, "dev")
+        dev_input_list = eval.prepare_inputs(task, task_type, "dev", ratio=ratio)
         model_paths = model_swarm.get_model_paths()
         list_of_input_list = [dev_input_list for _ in model_paths]
         list_of_output_list = distributed_generation.distributed_generation(
@@ -81,7 +82,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
         list_of_dev_scores = []
         for i in range(len(model_paths)):
             dev_outputs = list_of_output_list[i]
-            dev_score = eval.get_scores(task, task_type, "dev", dev_outputs)
+            dev_score = eval.get_scores(task, task_type, "dev", dev_outputs, ratio=ratio)
             avg_dev_score = sum(dev_score) / len(dev_score)
             list_of_dev_scores.append(avg_dev_score)
             print("Model: {}, dev {} score: {}".format(model_paths[i], task, avg_dev_score))
@@ -96,7 +97,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
 
     # evaluate the global best model on the test set
     best_model_path = model_swarm.get_global_best_path()
-    test_input_list = eval.prepare_inputs(task, task_type, "test")
+    test_input_list = eval.prepare_inputs(task, task_type, "test", ratio=ratio)
     test_outputs = distributed_generation.distributed_generation(
         [best_model_path],
         [test_input_list],
@@ -104,7 +105,7 @@ def run_method(task, task_type, gpu_ids, model_names, hyperparameters):
     )
     test_outputs = test_outputs[0]
 
-    test_scores = eval.get_scores(task, task_type, "test", test_outputs)
+    test_scores = eval.get_scores(task, task_type, "test", test_outputs, ratio=ratio)
     avg_test_score = sum(test_scores) / len(test_scores)
 
     # save the logs


### PR DESCRIPTION
Thread a single `ratio = hyperparameters.get("ratio", 1.0)` into every method's run_method and pass ratio=ratio to all eval.prepare_inputs and eval.get_scores calls for both dev and test splits. Fix heterogeneous swarms, which previously used its own 0.25 default and omitted ratio on the test calls.