### PR TITLE
Fix normalize_answer stripping math operators and inconsistent whites…

### DIFF
--- a/model_collaboration/data/eval.py
+++ b/model_collaboration/data/eval.py
@@ -161,7 +161,13 @@ def normalize_answer(s: str) -> str:
         return ' '.join(text.split())
 
     def remove_punc(text):
-        return text.translate(str.maketrans('', '', string.punctuation))
+        # Preserve math operators so expressions like "x+1" and "x-1" stay distinct.
+        math_chars = set('+-*/^=<>%')
+        punc_to_remove = ''.join(c for c in string.punctuation if c not in math_chars)
+        text = text.translate(str.maketrans('', '', punc_to_remove))
+        # Remove spaces around math operators so "x + 1" and "x+1" normalize identically.
+        text = re.sub(r'\s*([+\-*/^=<>%])\s*', r'\1', text)
+        return text
 
     def lower(text):
         try:


### PR DESCRIPTION
Preserves +, -, *, /, ^, =, <, >, % from punctuation removal so distinct expressions like "x+1" and "x-1" remain distinguishable. Also collapses spaces around operators so "x + 1" and "x+1" normalize identically.

Fixes #122.