### PR TITLE
het_swarms stable softmax + bf16 Long-index fixes (generation + DPO)

### DIFF
--- a/model_collaboration/method/distributed_generation.py
+++ b/model_collaboration/method/distributed_generation.py
@@ -38,17 +38,45 @@ def _strip_assistant_final(text: str) -> str:
         return text[idx + len("assistantfinal"):].strip()
     return text
 
+def _register_embedding_long_hook(model):
+    """Recover Long embedding indices at the embedding boundary.
+    Loading bfloat16 models can cause input_ids to be cast to a float dtype under
+    some transformers/PEFT versions, breaking nn.Embedding lookups. Only float32/
+    float64 indices are recovered (they represent vocab-size ints exactly); a
+    fp16/bf16 index is rejected -- it is already lossy (bf16 is exact only to 256,
+    fp16 to 2048), so casting it to Long would silently corrupt token IDs."""
+    import torch.nn as nn
+    def _cast_to_long(module, args):
+        def to_long(x):
+            if isinstance(x, torch.Tensor) and x.is_floating_point():
+                if x.dtype in (torch.float16, torch.bfloat16):
+                    raise TypeError(
+                        f"nn.Embedding received a {x.dtype} index tensor; casting to "
+                        f"Long would silently corrupt token IDs (fp16/bf16 cannot "
+                        f"exactly represent vocab indices). Fix the upstream cast."
+                    )
+                return x.long()
+            return x
+        return tuple(to_long(x) for x in args)
+    for module in model.modules():
+        if isinstance(module, nn.Embedding):
+            module.register_forward_pre_hook(_cast_to_long)
+
+
 def _load_model(model_name, device_map, load_in_8bit=False):
     if load_in_8bit and model_name not in NO_8BIT_MODELS:
         quant_config = BitsAndBytesConfig(load_in_8bit=True)
-        return AutoModelForCausalLM.from_pretrained(
+        model = AutoModelForCausalLM.from_pretrained(
             model_name, quantization_config=quant_config,
             device_map=device_map, trust_remote_code=True
         )
-    return AutoModelForCausalLM.from_pretrained(
-        model_name, torch_dtype=torch.bfloat16,
-        device_map=device_map, trust_remote_code=True
-    )
+    else:
+        model = AutoModelForCausalLM.from_pretrained(
+            model_name, torch_dtype=torch.bfloat16,
+            device_map=device_map, trust_remote_code=True
+        )
+    _register_embedding_long_hook(model)
+    return model
 
 def update_generation_hyperparameters(max_response_length, temperature, top_p, batch_size, big_model_mode=False, load_in_8bit=False):
     global MAX_RESPONSE_LENGTH, TEMPERATURE, TOP_P, BATCH_SIZE, BIG_MODEL_MODE, LOAD_IN_8BIT

--- a/model_collaboration/method/text_heterogeneous_swarms.py
+++ b/model_collaboration/method/text_heterogeneous_swarms.py
@@ -29,14 +29,27 @@ def softmax(probs):
         probs: np.ndarray, shape (n, ), probabilities after softmax.
     zero terms are not considered in the softmax operation.
     """
-    probs = np.array(probs)
-    probs = np.exp(probs)
-    for i in range(len(probs)):
-        if probs[i] == np.exp(0): # 0 means 0, no edge
-            probs[i] = 0
-    probs = probs / np.sum(probs)
-    assert sum(probs) >= 0.999 and sum(probs) <= 1.001
-    return probs
+    probs = np.array(probs, dtype=float)
+    out = np.zeros_like(probs)
+    mask = probs != 0  # 0 means no edge, excluded from the softmax
+    vals = probs[mask]
+    if vals.size == 0:
+        out[:] = 1.0 / len(out)  # degenerate: no edges -> uniform so downstream sampling stays valid
+        return out
+    if np.any(np.isposinf(vals)):
+        # +inf score(s) -- e.g. 1/0 when a PSO row-sum is exactly 0 -- dominate the
+        # softmax limit: all mass is shared uniformly among them, finite entries -> 0.
+        weights = np.isposinf(vals).astype(float)
+    else:
+        finite = np.isfinite(vals)  # excludes -inf and NaN, which contribute no mass
+        weights = np.zeros_like(vals)
+        if np.any(finite):
+            weights[finite] = np.exp(vals[finite] - np.max(vals[finite]))  # shift for numerical stability (softmax is shift-invariant); avoids exp overflow when 1/value is huge
+        else:
+            weights[:] = 1.0  # all edges non-finite (-inf/NaN) -> uniform over them
+    out[mask] = weights / weights.sum()
+    assert out.sum() >= 0.999 and out.sum() <= 1.001
+    return out
 
 def top_p_sampling_selection(probs, top_p_threshold):
     """

--- a/model_collaboration/utils/distributed_dpo.py
+++ b/model_collaboration/utils/distributed_dpo.py
@@ -2,7 +2,9 @@
 The helper functions for distributed DPO.
 """
 import os
+import atexit
 import torch
+import torch.nn as nn
 import shutil
 import random
 from tqdm import tqdm
@@ -14,6 +16,74 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 from trl import DPOConfig, DPOTrainer, DataCollatorForCompletionOnlyLM
 from model_collaboration.utils import lora_check
 
+
+def _index_to_long(index):
+    """Recover a Long index from a floating-point one, but only losslessly.
+    float32/float64 represent vocab-size integers exactly, so casting is safe;
+    a fp16/bf16 index is already corrupted (bf16 is exact only to 256, fp16 to
+    2048, both well below typical vocab sizes), so we fail fast rather than
+    coerce silently and train/generate on wrong token IDs."""
+    if isinstance(index, torch.Tensor) and index.is_floating_point():
+        if index.dtype in (torch.float16, torch.bfloat16):
+            raise TypeError(
+                f"Received a {index.dtype} index tensor; casting to Long would "
+                f"silently corrupt indices (fp16/bf16 cannot exactly represent "
+                f"vocab-size ints). Fix the upstream cast instead of coercing here."
+            )
+        return index.long()
+    return index
+
+
+def _register_embedding_long_hook(model):
+    """
+    Under bf16 AMP some trl/transformers versions cast input_ids to a float dtype
+    before the forward pass, causing nn.Embedding to crash (indices must be Long).
+    This hook recovers Long indices at the embedding boundary from float32/float64
+    only; a fp16/bf16 index is rejected (see _index_to_long) because its token IDs
+    would already be corrupted.
+    """
+    def _cast_to_long(module, args):
+        return tuple(_index_to_long(x) for x in args)
+    for module in model.modules():
+        if isinstance(module, nn.Embedding):
+            module.register_forward_pre_hook(_cast_to_long)
+
+_GATHER_PATCHED = False
+
+def _patch_torch_gather():
+    """
+    TRL's DPOTrainer casts batch tensors (including integer labels/input_ids) to
+    the model dtype before the log-probability gather call, producing a float index
+    that crashes torch.gather.  We wrap torch.gather / Tensor.gather to recover a
+    Long index from a losslessly-castable (float32/float64) one; fp16/bf16 indices
+    are rejected rather than silently corrupted (see _index_to_long).
+
+    The patch is idempotent (safe to call more than once per process) and restores
+    the original functions at interpreter exit so it cannot leak into unrelated code.
+    """
+    global _GATHER_PATCHED
+    if _GATHER_PATCHED:
+        return
+    _orig_gather = torch.gather
+    _orig_tensor_gather = torch.Tensor.gather
+
+    def _safe_gather(input, dim, index, *args, **kwargs):
+        return _orig_gather(input, dim, _index_to_long(index), *args, **kwargs)
+
+    def _safe_tensor_gather(self, dim, index, *args, **kwargs):
+        return _orig_tensor_gather(self, dim, _index_to_long(index), *args, **kwargs)
+
+    torch.gather = _safe_gather
+    torch.Tensor.gather = _safe_tensor_gather
+
+    def _restore():
+        torch.gather = _orig_gather
+        torch.Tensor.gather = _orig_tensor_gather
+    atexit.register(_restore)
+
+    _GATHER_PATCHED = True
+
+
 def single_dpo(model_name, dpo_data_path, gpu_id, output_model_path, batch_size=1, gradient_accumulation_steps=16,
                learning_rate=1e-6, epoch=1):
     """
@@ -23,6 +93,7 @@ def single_dpo(model_name, dpo_data_path, gpu_id, output_model_path, batch_size=
     gpu_id: the GPU id you want to use.
     output_model_path: the path to save the DPO model.
     """
+    _patch_torch_gather()   # fix TRL casting gather indices to float
     os.environ["CUDA_VISIBLE_DEVICES"] = str(gpu_id)
     torch.cuda.set_device(0)
 
@@ -53,6 +124,8 @@ def single_dpo(model_name, dpo_data_path, gpu_id, output_model_path, batch_size=
         # Load base model directly
         model = AutoModelForCausalLM.from_pretrained(model_name, torch_dtype=torch.bfloat16, device_map="auto")
 
+    _register_embedding_long_hook(model)
+
     if os.path.exists(output_model_path):
         print(f"Model path {output_model_path} exists. Deleting it to avoid conflicts.")
         shutil.rmtree(output_model_path)
@@ -72,7 +145,10 @@ def single_dpo(model_name, dpo_data_path, gpu_id, output_model_path, batch_size=
         per_device_train_batch_size=batch_size,
         per_device_eval_batch_size=batch_size,
         gradient_accumulation_steps=gradient_accumulation_steps,
-        bf16=True,
+        # bf16=True causes AMP to cast ALL tensors (including integer labels/input_ids)
+        # to bfloat16, breaking embedding lookups and gather() calls. The model is
+        # already loaded in bfloat16 via torch_dtype, so AMP is unnecessary here.
+        bf16=False,
         learning_rate=learning_rate,
         lr_scheduler_type="cosine",
         warmup_ratio = 0.1,


### PR DESCRIPTION
text_heterogeneous_swarms: numerically stable softmax (shift by max of non-zero edge entries before exp) -- the old np.exp(probs) overflowed to inf/NaN when graph_decode's 1/value went huge on a near-zero PSO row-sum, tripping the normalization assert and killing coalitions (group_8 agieval drop parti_3/4/12). Shift-invariant so results are unchanged; degenerate all-zero -> uniform.

distributed_generation: _register_embedding_long_hook casts float index tensors back to Long at nn.Embedding boundaries (bf16/PEFT loading can cast input_ids to float, breaking Embedding/gather).

distributed_dpo: same embedding Long hook + a torch.gather monkey-patch (per worker) for TRL DPOTrainer casting integer labels to model dtype and crashing the log-prob gather.